### PR TITLE
Crash if message id is not in network

### DIFF
--- a/can.js
+++ b/can.js
@@ -123,7 +123,7 @@ DatabaseService.prototype.onMessage = function (msg) {
 	var m = this.messages[id];
 	
 	if (!m)
-		console.log(this.messages[id].name + " not found");
+		console.log("Message ID " + msg.id + " not found");
 	
 	// Let the C-Portition extract and convert the signal
 	for (i in m.signals) {


### PR DESCRIPTION
If var m = this.messages[id] is undefined the log message two lines down does fail as name is undefined, too.
