### PR TITLE
disableLoopback in a can channel

### DIFF
--- a/src/raw.cc
+++ b/src/raw.cc
@@ -359,6 +359,15 @@ Handle<Value> RawChannel::Send(const Arguments& args)
     // Get frame data
     frame.can_dlc = Buffer::Length(dataArg->ToObject());
     memcpy(frame.data, Buffer::Data(dataArg->ToObject()), frame.can_dlc);
+
+    { // set timestamp when sending data
+      struct timeval now;
+      if ( 0==gettimeofday(&now, 0)) {
+        obj->Set(tssec_symbol, Uint32::New(now.tv_sec), PropertyAttribute(None));
+        obj->Set(tsusec_symbol, Uint32::New(now.tv_usec), PropertyAttribute(None));      
+      }
+    }
+    
     int i = send(hw->m_SocketFd, &frame, sizeof(struct can_frame), 0);
 
     return Int32::New(i);

--- a/src/raw.h
+++ b/src/raw.h
@@ -104,6 +104,13 @@ public:
      */
     static Handle<Value> SetRxFilters(const Arguments& args);
 
+
+    /**
+     * Disable loopback of channel. By default it is activated
+     * @method disableLoopback
+     */
+    static Handle<Value> DisableLoopback(const Arguments& args);
+
     // UV async callbacks
     DEFINE_ASYNC_CB(RawChannel, async_receiver_ready);
 


### PR DESCRIPTION
canChannel.disableLoopback() allows hidding sent messages to other channels connected to the same can device.

see also https://github.com/sebi2k1/node-can/issues/3

```javascript
var can = require('can');

var listen       = can.createRawChannel("can0", true);
var sendStandard = can.createRawChannel("can0", true);
var sendHidden   = can.createRawChannel("can0", true);
sendHidden.disableLoopback();

// Log messages comming to can0 except those comming from sendHidden
listen.addListener("onMessage", function(msg) { console.log(msg); } );

listen.start();
sendStandard.start();
sendHidded.start();
```
