### PR TITLE
revert change which broke little endian encode/decode. Fix signal conversion test.

### DIFF
--- a/src/signals.cc
+++ b/src/signals.cc
@@ -47,33 +47,20 @@ static u_int64_t _getvalue(u_int8_t * data,
 
     if (byteOrder == ENDIANESS_INTEL)
     {
-        //d <<= offset;
+        d <<= offset;
 
-        size_t intraByteOffset = offset % 8;
-        size_t thisByte = offset / 8;
+        size_t i, left = length;
 
-        size_t bitsLeft = length;
-        size_t outputShift = 0;
-
-        bool initial_pass = true;
-        for (; bitsLeft > 0 ;)
+        for (i = 0; i < length;)
         {
-            size_t bitsCopied = bitsLeft >= 8 ? 8 : bitsLeft;
-            if ( initial_pass && bitsLeft != intraByteOffset )
-                bitsCopied -= intraByteOffset;
+            size_t next_shift = left >= 8 ? 8 : left;
+            size_t shift = 64 - (i + next_shift);
+            size_t m = next_shift < 8 ? 0xFF >> next_shift : 0xFF;
 
-            size_t shift = 56 - (8 * thisByte);
-            if( initial_pass )
-                shift += intraByteOffset;
+            o |= ((d >> shift) & m) << i;
 
-            uint64_t byteMask = ((1 << bitsCopied) - 1); // 0x1111
-
-            o |= ((d >> shift) & byteMask) << outputShift ;
-
-            thisByte++;
-            initial_pass = false;
-            bitsLeft -= bitsCopied;
-            outputShift += bitsCopied;
+            left -= 8;
+            i += next_shift;
         }
     }
     else
@@ -141,45 +128,22 @@ void _setvalue(u_int32_t offset, u_int32_t bitLength, ENDIANESS endianess, u_int
 
     if (endianess == ENDIANESS_INTEL)
     {
-        size_t bitsLeft = bitLength;
-        size_t intraByteOffset = offset % 8;
-        size_t thisByte = offset / 8;  // 8 offset = 8/8 byte 1
-        // add the initial intrabyte Offset ... only matters the first time.
-        // if (12 o 8 l)
-        //             this byte
-        //           at iBO
-        //             3210 xxxx|xxxx 7654
-        //  |.... ....|.... ....|.... ....|
-        //
-        // if (8 o 19 l)
-        //             7654 3210 fedc ba98 xxxx x(+3
-        //  |.... ....|.... ....|.... ....|.... ....|
-        //
+        size_t left = bitLength;
 
-        bool initial_pass = true;
-        // while there are bits to process
-        for ( ; bitsLeft > 0; )
+        size_t source = 0;
+
+        for (source = 0; source < bitLength; )
         {
-            // process 8 at a time
-            //    what about starting at offset and moving 8 bits
-            //      ? it would be 4 and 4
-            //  bitsMoved =
-            size_t bitsMoved = bitsLeft < 8 ? bitsLeft : 8;
-            if ( initial_pass && bitsLeft != intraByteOffset)
-                bitsMoved -= intraByteOffset;
-            size_t shift = 56 - ( 8 * thisByte );
-            if (initial_pass)
-                shift += intraByteOffset;
+            size_t next_shift = left < 8 ? left : 8;
+            size_t shift = (64 - offset - next_shift) - source;
+            uint64_t m = ((1 << next_shift) - 1);
 
-            uint64_t byteMask = ((1 << bitsMoved) - 1);
+            o &= ~(m << shift);
+            o |= (raw_value & m) << shift;
 
-            o &= ~(byteMask << shift );
-            o |= (raw_value & byteMask) << shift;
-
-            raw_value >>= bitsMoved;
-            initial_pass = false;
-            thisByte++; // move to next Byte
-            bitsLeft -= bitsMoved; // decrement the bits processed
+            raw_value >>= 8;
+            source += next_shift;
+            left -= next_shift;
         }
     }
     else

--- a/tests/test-signal_conversion.js
+++ b/tests/test-signal_conversion.js
@@ -12,17 +12,15 @@ console.log(data);
 console.log(data);
 	signals.encode_signal(data, 3, 1, true, false, 1);
 console.log(data);
-	test.deepEqual(data, [0xD0, 0x00, 0x00, 0, 0, 0, 0, 0]);
-/*	
+	test.deepEqual(data, new Buffer([0xD0, 0x00, 0x00, 0, 0, 0, 0, 0]));
 	signals.encode_signal(data, 4, 8, true, false, 0xEA);
-	test.deepEqual(data, [0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 12, 12, true, false, 0xEDB);
-	test.deepEqual(data, [0xDE, 0xAD, 0xBE, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xDE, 0xAD, 0xBE, 0, 0, 0, 0, 0]));
 
 	signals.encode_signal(data, 12, 12, true, false, 0);
-	test.deepEqual(data, [0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0], "Overwriting signal value failed");
-*/	
+	test.deepEqual(data, new Buffer([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]), "Overwriting signal value failed");
 	test.done();
 }
 
@@ -59,13 +57,13 @@ exports['little_endian_signed_encode'] = function(test) {
 	data = new Buffer([0, 0, 0, 0, 0, 0, 0, 0]);
 	
 	signals.encode_signal(data, 0, 8, true, true, -1);
-	test.deepEqual(data, [0xFF, 0x00, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xFF, 0x00, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 0, 16, true, true, -2);
-	test.deepEqual(data, [0xFE, 0xFF, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xFE, 0xFF, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 16, 8, true, true, -128);
-	test.deepEqual(data, [0xFE, 0xFF, 0x80, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xFE, 0xFF, 0x80, 0, 0, 0, 0, 0]));
 	
 	test.done();
 }
@@ -77,16 +75,16 @@ exports['big_endian_encode'] = function(test) {
 	signals.encode_signal(data, 1, 1, false, false, 1);
 	signals.encode_signal(data, 2, 1, false, false, 0);
 	signals.encode_signal(data, 3, 1, false, false, 1);
-	test.deepEqual(data, [0xD0, 0x00, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xD0, 0x00, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 11, 8, false, false, 0xEA);
-	test.deepEqual(data, [0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 23, 12, false, false, 0xDBE);
-	test.deepEqual(data, [0xDE, 0xAD, 0xBE, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xDE, 0xAD, 0xBE, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 23, 12, false, false, 0);
-	test.deepEqual(data, [0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0], "Overwriting signal value failed");
+	test.deepEqual(data, new Buffer([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]), "Overwriting signal value failed");
 	
 	test.done();
 }
@@ -109,13 +107,13 @@ exports['big_endian_signed_encode'] = function(test) {
 	data = new Buffer([0, 0, 0, 0, 0, 0, 0, 0]);
 	
 	signals.encode_signal(data, 7, 8, false, true, -1);
-	test.deepEqual(data, [0xFF, 0x00, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xFF, 0x00, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 15, 16, false, true, -2);
-	test.deepEqual(data, [0xFF, 0xFE, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xFF, 0xFE, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 23, 8, false, true, -128);
-	test.deepEqual(data, [0xFF, 0xFE, 0x80, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xFF, 0xFE, 0x80, 0, 0, 0, 0, 0]));
 	
 	test.done();
 }


### PR DESCRIPTION
Revert "Changes for little Endianess and intra-Byte signal definitions", as it broke little endian encoding and decoding.  It is not clear what the change was attempting to fix.

Reverting this change and correcting array->buffer in the tests allows all signal conversion tests to pass.  Without reverting the mentioned change, the little endian bit order is wrong and 11 assertions fail.

 test-signal_conversion.js
-Buffer 01 00 00 00 00 00 00 00
-Buffer 03 00 00 00 00 00 00 00
-Buffer 03 00 00 00 00 00 00 00
-Buffer 0b 00 00 00 00 00 00 00
-✖ little_endian_encode
-✖ little_endian_decode
+Buffer 80 00 00 00 00 00 00 00
+Buffer c0 00 00 00 00 00 00 00
+Buffer c0 00 00 00 00 00 00 00
+Buffer d0 00 00 00 00 00 00 00
+✔ little_endian_encode
+✔ little_endian_decode
 ✔ little_endian_signed_decode
 ✔ little_endian_signed_encode
 ✔ big_endian_encode
@@ -13,4 +13,4 @@
 ✔ big_endian_signed_encode
 ✔ big_endian_signed_decode
 
-FAILURES: 11/36 assertions failed (12ms)
+OK: 36 assertions (9ms)

