### PR TITLE
simplified setvalue/getvalue, verified with Kayak. Updated test cases.

### DIFF
--- a/src/signals.cc
+++ b/src/signals.cc
@@ -61,6 +61,27 @@ static u_int64_t _getvalue(u_int8_t * data,
 
     o = (d >> shift) & m;
 
+#ifdef KAYAK_DATA_CHECK
+    size_t i;
+    int bitNr;
+    uint64_t val = 0;
+    if (byteOrder == ENDIANESS_INTEL) {
+        for (i = 0; i < length; i++) {
+            bitNr = i + offset;
+            val |= ((data[bitNr >> 3] >> (bitNr & 0x07)) & 1) << i;
+        }
+    } else {
+        for (i = 0; i < length; i++) {
+            bitNr = offset + length - i -1;
+            val |= ((data[bitNr >> 3] >> (7-(bitNr & 0x07))) & 1) << i;
+        }
+    }
+    
+    if (val != o) {
+        fprintf(stderr, "getvalue: got %lu, expected %lu\n", val, o);
+    }
+#endif
+
     return o;
 }
 
@@ -138,6 +159,26 @@ void _setvalue(u_int32_t offset, u_int32_t bitLength, ENDIANESS endianess, u_int
     }
 
     memcpy(&data[0], &o, 8);
+
+#ifdef KAYAK_DATA_CHECK
+    size_t i;
+    int bitNr;
+    uint64_t val = 0;
+    if (endianess == ENDIANESS_INTEL) {
+        for (i = 0; i < bitLength; i++) {
+            bitNr = i + offset;
+            val |= ((data[bitNr >> 3] >> (bitNr & 0x07)) & 1) << i;
+        }
+    } else {
+        for (i = 0; i < bitLength; i++) {
+            bitNr = offset + bitLength - i -1;
+            val |= ((data[bitNr >> 3] >> (7-(bitNr & 0x07))) & 1) << i;
+        }
+    }
+    if(val != ( raw_value & m)) {
+        fprintf(stderr, "setvalue: got %lu, expected %lu\n", val, raw_value & m);
+    }
+#endif
 }
 
 // Encode signal according description

--- a/src/signals.cc
+++ b/src/signals.cc
@@ -42,48 +42,24 @@ static u_int64_t _getvalue(u_int8_t * data,
                            u_int32_t length,
                            ENDIANESS byteOrder)
 {
-    uint64_t d = be64toh(*((uint64_t *)&data[0]));
+    uint64_t d;
     uint64_t o = 0;
 
-    if (byteOrder == ENDIANESS_INTEL)
-    {
-        //d <<= offset;
-
-        size_t intraByteOffset = offset % 8;
-        size_t thisByte = offset / 8;
-
-        size_t bitsLeft = length;
-        size_t outputShift = 0;
-
-        bool initial_pass = true;
-        for (; bitsLeft > 0 ;)
-        {
-            size_t bitsCopied = bitsLeft >= 8 ? 8 : bitsLeft;
-            if ( initial_pass && bitsLeft != intraByteOffset )
-                bitsCopied -= intraByteOffset;
-
-            size_t shift = 56 - (8 * thisByte);
-            if( initial_pass )
-                shift += intraByteOffset;
-
-            uint64_t byteMask = ((1 << bitsCopied) - 1); // 0x1111
-
-            o |= ((d >> shift) & byteMask) << outputShift ;
-
-            thisByte++;
-            initial_pass = false;
-            bitsLeft -= bitsCopied;
-            outputShift += bitsCopied;
-        }
+    if (byteOrder == ENDIANESS_INTEL) {
+        d = le64toh(*((uint64_t *)&data[0]));
+    } else {
+        d = be64toh(*((uint64_t *)&data[0]));
     }
-    else
-    {
-        uint64_t m = UINT64_MAX;
-        size_t shift = 64 - offset - 1;
 
-        m = (1 << length) - 1;
-        o = (d >> shift) & m;
+    uint64_t m = (1 << length) - 1;
+    size_t shift;
+    if (byteOrder == ENDIANESS_INTEL) {
+        shift = offset;
+    } else {
+        shift = 64 - offset - length;
     }
+
+    o = (d >> shift) & m;
 
     return o;
 }
@@ -137,61 +113,29 @@ NAN_METHOD(DecodeSignal)
 
 void _setvalue(u_int32_t offset, u_int32_t bitLength, ENDIANESS endianess, u_int8_t data[8], u_int64_t raw_value)
 {
-    uint64_t o = be64toh(*(uint64_t *)&data[0]);
-
-    if (endianess == ENDIANESS_INTEL)
-    {
-        size_t bitsLeft = bitLength;
-        size_t intraByteOffset = offset % 8;
-        size_t thisByte = offset / 8;  // 8 offset = 8/8 byte 1
-        // add the initial intrabyte Offset ... only matters the first time.
-        // if (12 o 8 l)
-        //             this byte
-        //           at iBO
-        //             3210 xxxx|xxxx 7654
-        //  |.... ....|.... ....|.... ....|
-        //
-        // if (8 o 19 l)
-        //             7654 3210 fedc ba98 xxxx x(+3
-        //  |.... ....|.... ....|.... ....|.... ....|
-        //
-
-        bool initial_pass = true;
-        // while there are bits to process
-        for ( ; bitsLeft > 0; )
-        {
-            // process 8 at a time
-            //    what about starting at offset and moving 8 bits
-            //      ? it would be 4 and 4
-            //  bitsMoved =
-            size_t bitsMoved = bitsLeft < 8 ? bitsLeft : 8;
-            if ( initial_pass && bitsLeft != intraByteOffset)
-                bitsMoved -= intraByteOffset;
-            size_t shift = 56 - ( 8 * thisByte );
-            if (initial_pass)
-                shift += intraByteOffset;
-
-            uint64_t byteMask = ((1 << bitsMoved) - 1);
-
-            o &= ~(byteMask << shift );
-            o |= (raw_value & byteMask) << shift;
-
-            raw_value >>= bitsMoved;
-            initial_pass = false;
-            thisByte++; // move to next Byte
-            bitsLeft -= bitsMoved; // decrement the bits processed
-        }
-    }
-    else
-    {
-        uint64_t m = ((1 << bitLength) - 1);
-        size_t shift = 64 - offset - 1;
-
-        o &= ~(m << shift);
-        o |= (raw_value & m) << shift;
+    uint64_t o;
+    if (endianess == ENDIANESS_INTEL) {
+        o = le64toh(*((uint64_t *)&data[0]));
+    } else {
+        o = be64toh(*((uint64_t *)&data[0]));
     }
 
-    o = htobe64(o);
+    uint64_t m = ((1 << bitLength) - 1);
+    size_t shift;
+    if (endianess == ENDIANESS_INTEL) {
+        shift = offset;
+    } else {
+        shift = 64 - offset - bitLength;
+    }
+
+    o &= ~(m << shift);
+    o |= (raw_value & m) << shift;
+
+    if (endianess == ENDIANESS_INTEL) {
+        o = htole64(o);
+    } else {
+        o = htobe64(o);
+    }
 
     memcpy(&data[0], &o, 8);
 }

--- a/tests/test-signal_conversion.js
+++ b/tests/test-signal_conversion.js
@@ -12,32 +12,32 @@ console.log(data);
 console.log(data);
 	signals.encode_signal(data, 3, 1, true, false, 1);
 console.log(data);
-	test.deepEqual(data, new Buffer([0xD0, 0x00, 0x00, 0, 0, 0, 0, 0]));
+	test.deepEqual(data, new Buffer([0x0B, 0x00, 0x00, 0, 0, 0, 0, 0]));
 	signals.encode_signal(data, 4, 8, true, false, 0xEA);
-	test.deepEqual(data, new Buffer([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]));
+	test.deepEqual(data, new Buffer([0xAB, 0x0E, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 12, 12, true, false, 0xEDB);
-	test.deepEqual(data, new Buffer([0xDE, 0xAD, 0xBE, 0, 0, 0, 0, 0]));
+	test.deepEqual(data, new Buffer([0xAB, 0xBE, 0xED, 0, 0, 0, 0, 0]));
 
 	signals.encode_signal(data, 12, 12, true, false, 0);
-	test.deepEqual(data, new Buffer([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]), "Overwriting signal value failed");
+	test.deepEqual(data, new Buffer([0xAB, 0x0E, 0x00, 0, 0, 0, 0, 0]), "Overwriting signal value failed");
 	test.done();
 }
 
 exports['little_endian_decode'] = function(test) {
 	data = new Buffer([0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE]);
-	
+
 	test.equals(signals.decode_signal(data, 0, 8, true, false), 0xDE);
-	test.equals(signals.decode_signal(data, 0, 12, true, false), 0xADE);
+	test.equals(signals.decode_signal(data, 0, 12, true, false), 0xDDE);
 	test.equals(signals.decode_signal(data, 0, 16, true, false), 0xADDE);
 	
-	test.equals(signals.decode_signal(data, 12, 8, true, false), 0xDB);
-	test.equals(signals.decode_signal(data, 12, 12, true, false), 0xEDB);
-	test.equals(signals.decode_signal(data, 12, 20, true, false), 0xFEEDB);
+	test.equals(signals.decode_signal(data, 12, 8, true, false), 0xEA);
+	test.equals(signals.decode_signal(data, 12, 12, true, false), 0xBEA);
+	test.equals(signals.decode_signal(data, 12, 20, true, false), 0xEFBEA);
 	
-	test.equals(signals.decode_signal(data, 0, 1, true, false), 1);
+	test.equals(signals.decode_signal(data, 0, 1, true, false), 0);
 	test.equals(signals.decode_signal(data, 1, 1, true, false), 1);
-	test.equals(signals.decode_signal(data, 2, 1, true, false), 0);
+	test.equals(signals.decode_signal(data, 2, 1, true, false), 1);
 	test.equals(signals.decode_signal(data, 3, 1, true, false), 1);
 	
 	test.done();
@@ -77,13 +77,13 @@ exports['big_endian_encode'] = function(test) {
 	signals.encode_signal(data, 3, 1, false, false, 1);
 	test.deepEqual(data, new Buffer([0xD0, 0x00, 0x00, 0, 0, 0, 0, 0]));
 	
-	signals.encode_signal(data, 11, 8, false, false, 0xEA);
+	signals.encode_signal(data, 4, 8, false, false, 0xEA);
 	test.deepEqual(data, new Buffer([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]));
 	
-	signals.encode_signal(data, 23, 12, false, false, 0xDBE);
+	signals.encode_signal(data, 12, 12, false, false, 0xDBE);
 	test.deepEqual(data, new Buffer([0xDE, 0xAD, 0xBE, 0, 0, 0, 0, 0]));
-	
-	signals.encode_signal(data, 23, 12, false, false, 0);
+
+	signals.encode_signal(data, 12, 12, false, false, 0);
 	test.deepEqual(data, new Buffer([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]), "Overwriting signal value failed");
 	
 	test.done();
@@ -91,9 +91,12 @@ exports['big_endian_encode'] = function(test) {
 
 exports['big_endian_decode'] = function(test) {
 	data = new Buffer([0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE]);
-	
-	test.equals(signals.decode_signal(data, 7, 8, false, false), 0xDE);
-	test.equals(signals.decode_signal(data, 15, 16, false, false), 0xDEAD);
+
+	test.equals(signals.decode_signal(data, 0, 8, false, false), 0xDE);
+	test.equals(signals.decode_signal(data, 0, 16, false, false), 0xDEAD);
+
+	test.equals(signals.decode_signal(data, 7, 8, false, false), 0x56);
+	test.equals(signals.decode_signal(data, 15, 16, false, false), 0xDF77);
 	
 	test.equals(signals.decode_signal(data, 0, 1, false, false), 1);
 	test.equals(signals.decode_signal(data, 1, 1, false, false), 1);
@@ -106,13 +109,13 @@ exports['big_endian_decode'] = function(test) {
 exports['big_endian_signed_encode'] = function(test) {
 	data = new Buffer([0, 0, 0, 0, 0, 0, 0, 0]);
 	
-	signals.encode_signal(data, 7, 8, false, true, -1);
+	signals.encode_signal(data, 0, 8, false, true, -1);
 	test.deepEqual(data, new Buffer([0xFF, 0x00, 0x00, 0, 0, 0, 0, 0]));
 	
-	signals.encode_signal(data, 15, 16, false, true, -2);
+	signals.encode_signal(data, 0, 16, false, true, -2);
 	test.deepEqual(data, new Buffer([0xFF, 0xFE, 0x00, 0, 0, 0, 0, 0]));
 	
-	signals.encode_signal(data, 23, 8, false, true, -128);
+	signals.encode_signal(data, 16, 8, false, true, -128);
 	test.deepEqual(data, new Buffer([0xFF, 0xFE, 0x80, 0, 0, 0, 0, 0]));
 	
 	test.done();
@@ -121,9 +124,9 @@ exports['big_endian_signed_encode'] = function(test) {
 exports['big_endian_signed_decode'] = function(test) {
 	data = new Buffer([0xFF, 0xFE, 0x80 ]);
 	
-	test.equals(signals.decode_signal(data, 7, 8, false, true), -1);
-	test.equals(signals.decode_signal(data, 15, 16, false, true), -2);
-	test.equals(signals.decode_signal(data, 23, 8, false, true), -128);
+	test.equals(signals.decode_signal(data, 0, 8, false, true), -1);
+	test.equals(signals.decode_signal(data, 0, 16, false, true), -2);
+	test.equals(signals.decode_signal(data, 16, 8, false, true), -128);
 	
 	test.done();
 }

--- a/tests/test-signal_conversion.js
+++ b/tests/test-signal_conversion.js
@@ -12,17 +12,15 @@ console.log(data);
 console.log(data);
 	signals.encode_signal(data, 3, 1, true, false, 1);
 console.log(data);
-	test.deepEqual(data, [0xD0, 0x00, 0x00, 0, 0, 0, 0, 0]);
-/*	
+	test.deepEqual(data, new Buffer([0xD0, 0x00, 0x00, 0, 0, 0, 0, 0]));
 	signals.encode_signal(data, 4, 8, true, false, 0xEA);
-	test.deepEqual(data, [0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 12, 12, true, false, 0xEDB);
-	test.deepEqual(data, [0xDE, 0xAD, 0xBE, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xDE, 0xAD, 0xBE, 0, 0, 0, 0, 0]));
 
 	signals.encode_signal(data, 12, 12, true, false, 0);
-	test.deepEqual(data, [0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0], "Overwriting signal value failed");
-*/	
+	test.deepEqual(data, new Buffer([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]), "Overwriting signal value failed");
 	test.done();
 }
 
@@ -59,13 +57,13 @@ exports['little_endian_signed_encode'] = function(test) {
 	data = new Buffer([0, 0, 0, 0, 0, 0, 0, 0]);
 	
 	signals.encode_signal(data, 0, 8, true, true, -1);
-	test.deepEqual(data, [0xFF, 0x00, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xFF, 0x00, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 0, 16, true, true, -2);
-	test.deepEqual(data, [0xFE, 0xFF, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xFE, 0xFF, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 16, 8, true, true, -128);
-	test.deepEqual(data, [0xFE, 0xFF, 0x80, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xFE, 0xFF, 0x80, 0, 0, 0, 0, 0]));
 	
 	test.done();
 }
@@ -77,16 +75,16 @@ exports['big_endian_encode'] = function(test) {
 	signals.encode_signal(data, 1, 1, false, false, 1);
 	signals.encode_signal(data, 2, 1, false, false, 0);
 	signals.encode_signal(data, 3, 1, false, false, 1);
-	test.deepEqual(data, [0xD0, 0x00, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xD0, 0x00, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 11, 8, false, false, 0xEA);
-	test.deepEqual(data, [0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 23, 12, false, false, 0xDBE);
-	test.deepEqual(data, [0xDE, 0xAD, 0xBE, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xDE, 0xAD, 0xBE, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 23, 12, false, false, 0);
-	test.deepEqual(data, [0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0], "Overwriting signal value failed");
+	test.deepEqual(data, new Buffer([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]), "Overwriting signal value failed");
 	
 	test.done();
 }
@@ -109,13 +107,13 @@ exports['big_endian_signed_encode'] = function(test) {
 	data = new Buffer([0, 0, 0, 0, 0, 0, 0, 0]);
 	
 	signals.encode_signal(data, 7, 8, false, true, -1);
-	test.deepEqual(data, [0xFF, 0x00, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xFF, 0x00, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 15, 16, false, true, -2);
-	test.deepEqual(data, [0xFF, 0xFE, 0x00, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xFF, 0xFE, 0x00, 0, 0, 0, 0, 0]));
 	
 	signals.encode_signal(data, 23, 8, false, true, -128);
-	test.deepEqual(data, [0xFF, 0xFE, 0x80, 0, 0, 0, 0, 0]);
+	test.deepEqual(data, new Buffer([0xFF, 0xFE, 0x80, 0, 0, 0, 0, 0]));
 	
 	test.done();
 }


### PR DESCRIPTION
replace setvalue/getvalue with simple implementation that is verified with Kayak SignalDescription.java extractBits.
Update test cases to match implementation.
With all 'nodeunit tests/test-signal_conversion.js' tests passing.
