### PR TITLE
Bug fix in parse.kcd

### DIFF
--- a/parse_kcd.js
+++ b/parse_kcd.js
@@ -129,7 +129,7 @@ exports.parseKcdFile = function(file) {
 
 							var _s = {
 								name: signal.name,
-								mux : parseInt(muxmsg['count'],16),
+								mux : parseInt(muxmsg['count']),
 								bitLength: signal.length ? parseInt(signal.length) : 1,
 								endianess: signal.endianess ? signal.endianess : 'little',
 								spn : signal.spn,


### PR DESCRIPTION
Hi.
I have just noted a bug: The mux value was interpreted to base 16. Base 10 is correct. This is an extract of the kcd format definition:

### Hex Strings for IDs (see restriction tag):
```
<xs:attribute name="id" use="required">
[...]
  <xs:simpleType>
    <xs:restriction base="xs:string">
      <xs:pattern value="0x[A-F0-9]+"/>
    </xs:restriction>
  </xs:simpleType>
</xs:attribute>
```

### Counter for multiplexor values (see restriction tag):
``` 
<xs:element name="MuxGroup">
    <xs:annotation>
      <xs:documentation>A group of signals that is just valid when the count value of the group matches with the looping counter (Multiplex).</xs:documentation>
    </xs:annotation>
    <xs:complexType>
      <xs:sequence>
        <xs:element maxOccurs="unbounded" ref="Signal"/>
      </xs:sequence>
      <xs:attribute name="count" use="required">
        <xs:annotation>
          <xs:documentation>Count value of the Multiplex when the signals of this group become valid.</xs:documentation>
        </xs:annotation>
        <xs:simpleType>
          <xs:restriction base="xs:long">
            <xs:minInclusive value="0"/>
          </xs:restriction>
        </xs:simpleType>
      </xs:attribute>
    </xs:complexType>
  </xs:element>
```
Source:
[KCD Definiton](https://github.com/dschanoeh/Kayak/blob/master/Kayak-kcd/src/main/resources/com/github/kayak/canio/kcd/loader/Definition.xsd)