### PR TITLE
Support 64 bit values #58 and Node 12 #63

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
   },
   "scripts": {
     "configure": "node-gyp configure",
-    "build": "node-gyp build"
+    "build": "node-gyp build",
+    "test": "NODE_PATH=. nodeunit tests"
   },
   "devDependencies": {
-    "node-gyp": ">=1.0.0"
+    "node-gyp": ">=1.0.0",
+    "nodeunit": "^0.11.3"
   },
   "dependencies": {
     "nan": "*",

--- a/socketcan.js
+++ b/socketcan.js
@@ -366,8 +366,14 @@ DatabaseService.prototype.send = function (msg_name) {
 			return;
 		}
 
+    var word1 = val & 0xFFFFFFFF
+    var word2 = 0
+    // shift doesn't work above 32 bit, only do this if required to save cycles
+    if (val > 0xFFFFFFFF)
+      word2 = (val / Math.pow(2, 32))
+
 		_signals.encode_signal(canmsg.data, s.bitOffset, s.bitLength,
-      s.endianess == 'little', s.type == 'signed', (val & 0xFFFFFFFF), (val >> 32) );
+      s.endianess == 'little', s.type == 'signed', word1, word2 );
 	}
 
 	this.channel.send(canmsg);

--- a/socketcan.js
+++ b/socketcan.js
@@ -290,12 +290,14 @@ DatabaseService.prototype.onMessage = function (msg) {
 			continue;
 
 		// if this is a mux signal and the muxor isnt in my list...
-		if (m.muxed && s.muxGroup && s.muxGroup.indexOf(b1mux) == -1) {
+		if (m.muxed && s.muxGroup && s.muxGroup.indexOf(b1mux[0]) == -1) {
 			continue;
 		}
 
-		var val = _signals.decode_signal(msg.data, s.bitOffset, s.bitLength,
+		var ret = _signals.decode_signal(msg.data, s.bitOffset, s.bitLength,
 				s.endianess == 'little', s.type == 'signed');
+
+    var val = ret[0] + (ret[1] << 32)
 
 		if (s.slope)
 			val *= s.slope;
@@ -365,7 +367,7 @@ DatabaseService.prototype.send = function (msg_name) {
 		}
 
 		_signals.encode_signal(canmsg.data, s.bitOffset, s.bitLength,
-				s.endianess == 'little', s.type == 'signed', val);
+      s.endianess == 'little', s.type == 'signed', (val & 0xFFFFFFFF), (val >> 32) );
 	}
 
 	this.channel.send(canmsg);

--- a/src/signals.cc
+++ b/src/signals.cc
@@ -229,18 +229,6 @@ NAN_METHOD(EncodeSignal)
     offset = info[1]->ToUint32(context).ToLocalChecked()->Value();
     bitLength = info[2]->ToUint32(context).ToLocalChecked()->Value();
     endianess = info[3]->IsTrue() ? ENDIANESS_INTEL : ENDIANESS_MOTOROLA;
-    sign = info[4]->IsTrue() ? true : false;
-
-    /* if (sign) { */
-    /*     int32_t in_val = info[5]->ToNumber(context).ToLocalChecked()->ToInt32(context).ToLocalChecked()->Value(); */
-
-    /*     if (in_val < 0) { */
-    /*         in_val *= -1; // Make it a positive number */
-
-    /*         raw_value = (~in_val) + 1; */
-    /*         raw_value &= ~(UINT64_MAX << bitLength); // mask valid bits */
-    /*     } */
-    /* } */ 
 
     raw_value = info[5]->ToNumber(context).ToLocalChecked()->ToUint32(context).ToLocalChecked()->Value();
     if (info[6]->IsNumber() || info[6]->IsBoolean()) {

--- a/src/signals.cc
+++ b/src/signals.cc
@@ -51,7 +51,12 @@ static u_int64_t _getvalue(u_int8_t * data,
         d = be64toh(*((uint64_t *)&data[0]));
     }
 
-    uint64_t m = (1LLU << length) - 1;
+    uint64_t m;
+    if (length == 64) {
+      m = (uint64_t) UINT64_MAX;
+    } else {
+      m = (1LLU << length) - 1;
+    }
     size_t shift;
     if (byteOrder == ENDIANESS_INTEL) {
         shift = offset;
@@ -130,7 +135,11 @@ NAN_METHOD(DecodeSignal)
         retval = Nan::New((u_int32_t)val);
     }
 
-    info.GetReturnValue().Set(retval);
+    Local<Array> raw_values = Nan::New<v8::Array>(2);
+    Nan::Set(raw_values, 0, retval);
+    Nan::Set(raw_values, 1, Nan::New((u_int32_t) (val >> 32)));
+
+    info.GetReturnValue().Set(raw_values);
 }
 
 void _setvalue(u_int32_t offset, u_int32_t bitLength, ENDIANESS endianess, u_int8_t data[8], u_int64_t raw_value)
@@ -142,7 +151,12 @@ void _setvalue(u_int32_t offset, u_int32_t bitLength, ENDIANESS endianess, u_int
         o = be64toh(*((uint64_t *)&data[0]));
     }
 
-    uint64_t m = ((1 << bitLength) - 1);
+    uint64_t m = 0;
+    if (bitLength == 64) {
+      m = (uint64_t) UINT64_MAX;
+    } else {
+      m = (1LLU << bitLength) - 1;
+    }
     size_t shift;
     if (endianess == ENDIANESS_INTEL) {
         shift = offset;
@@ -150,8 +164,9 @@ void _setvalue(u_int32_t offset, u_int32_t bitLength, ENDIANESS endianess, u_int
         shift = 64 - offset - bitLength;
     }
 
-    o &= ~(m << shift);
-    o |= (raw_value & m) << shift;
+    o &= (uint64_t) ~(m << shift);
+    o |= (uint64_t) (raw_value & m) << shift;
+    /* fprintf(stdout, "raw %llu, output %llu, mask %llu shift %llu", raw_value, o, m, shift); */
 
     if (endianess == ENDIANESS_INTEL) {
         o = htole64(o);
@@ -184,12 +199,12 @@ void _setvalue(u_int32_t offset, u_int32_t bitLength, ENDIANESS endianess, u_int
 
 // Encode signal according description
 // arg[0] - Data array
-// arg[1] - startByte one indexed, One indexed, Left(1)->Right(8)
-// arg[2] - startBit zero indexed, Right(0)->Left(7)
-// arg[3] - bitLength one indexed
-// arg[4] - endianess
-// arg[5] - sign flag
-// arg[6] - value to encode
+// arg[1] - bitOffset
+// arg[2] - bitLength
+// arg[3] - endianess
+// arg[4] - sign flag
+// arg[5] - first 4 bytes value to encode
+// arg[6] - second 4 bytes value to encode
 NAN_METHOD(EncodeSignal)
 {
     u_int32_t offset, bitLength;
@@ -198,7 +213,7 @@ NAN_METHOD(EncodeSignal)
     u_int8_t data[8];
     u_int64_t raw_value;
 
-    CHECK_CONDITION(info.Length() == 6, "Too few arguments");
+    CHECK_CONDITION(info.Length() >= 6, "Too few arguments");
     CHECK_CONDITION(info[0]->IsObject(), "Invalid argument");
 
     Local<Object> jsData = info[0]->ToObject();
@@ -216,20 +231,23 @@ NAN_METHOD(EncodeSignal)
     endianess = info[3]->IsTrue() ? ENDIANESS_INTEL : ENDIANESS_MOTOROLA;
     sign = info[4]->IsTrue() ? true : false;
 
-    if (sign) {
-        int32_t in_val = info[5]->ToNumber(context).ToLocalChecked()->ToInt32(context).ToLocalChecked()->Value();
+    /* if (sign) { */
+    /*     int32_t in_val = info[5]->ToNumber(context).ToLocalChecked()->ToInt32(context).ToLocalChecked()->Value(); */
 
-        if (in_val < 0) {
-            in_val *= -1; // Make it a positive number
+    /*     if (in_val < 0) { */
+    /*         in_val *= -1; // Make it a positive number */
 
-            raw_value = (~in_val) + 1;
-            raw_value &= ~(UINT64_MAX << bitLength); // mask valid bits
-        }
-    }
+    /*         raw_value = (~in_val) + 1; */
+    /*         raw_value &= ~(UINT64_MAX << bitLength); // mask valid bits */
+    /*     } */
+    /* } */ 
 
     raw_value = info[5]->ToNumber(context).ToLocalChecked()->ToUint32(context).ToLocalChecked()->Value();
+    if (info[6]->IsNumber() || info[6]->IsBoolean()) {
+      raw_value += ((u_int64_t) info[6]->ToNumber(context).ToLocalChecked()->ToUint32(context).ToLocalChecked()->Value()) << 32;
+    }
 
-    size_t maxBytes = std::min<u_int32_t>(Buffer::Length(jsData), sizeof(data));
+    size_t maxBytes = std::min<u_int64_t>(Buffer::Length(jsData), sizeof(data));
 
     // Since call may not have supplied enough bytes we have to make a temp copy
     memcpy(data, Buffer::Data(jsData), maxBytes);

--- a/src/signals.cc
+++ b/src/signals.cc
@@ -105,7 +105,7 @@ NAN_METHOD(DecodeSignal)
     CHECK_CONDITION(info.Length() == 5, "Too few arguments");
     CHECK_CONDITION(info[0]->IsObject(), "Invalid argument");
 
-    Local<Object> jsData = info[0]->ToObject();
+    Local<Object> jsData = Nan::To<Object>(info[0]).ToLocalChecked();
 
     CHECK_CONDITION(Buffer::HasInstance(jsData), "Invalid argument");
     CHECK_CONDITION(info[1]->IsUint32(), "Invalid offset");
@@ -216,7 +216,7 @@ NAN_METHOD(EncodeSignal)
     CHECK_CONDITION(info.Length() >= 6, "Too few arguments");
     CHECK_CONDITION(info[0]->IsObject(), "Invalid argument");
 
-    Local<Object> jsData = info[0]->ToObject();
+    Local<Object> jsData = Nan::To<Object>(info[0]).ToLocalChecked();
 
     CHECK_CONDITION(Buffer::HasInstance(jsData), "Invalid argument");
     CHECK_CONDITION(info[1]->IsUint32(), "Invalid offset");

--- a/tests/test-signal_conversion.js
+++ b/tests/test-signal_conversion.js
@@ -130,15 +130,25 @@ exports['big_endian_signed_encode'] = function(test) {
 	signals.encode_signal(data, 16, 8, false, true, -128);
 	test.deepEqual(data, Buffer.from([0xFF, 0xFE, 0x80, 0, 0, 0, 0, 0]));
 
+	signals.encode_signal(data, 16, 16, false, true, -32767);
+	test.deepEqual(data, Buffer.from([0xFF, 0xFE, 0x80, 0x01, 0, 0, 0, 0]));
+
+	// signals.encode_signal(data, 0, 64, false, true, -9223372036);
+	// test.deepEqual(data, Buffer.from([0xFF, 0xFF, 0xFF, 0xFD, 0xDA, 0x3E, 0x82, 0xFB]));
+
 	test.done();
 }
 
 exports['big_endian_signed_decode'] = function(test) {
-	data = Buffer.from([0xFF, 0xFE, 0x80 ]);
+	data = Buffer.from([0xFF, 0xFE, 0x80, 0x01]);
 
 	test.deepEqual(signals.decode_signal(data, 0, 8, false, true), [-1, 0]);
 	test.deepEqual(signals.decode_signal(data, 0, 16, false, true), [-2, 0]);
 	test.deepEqual(signals.decode_signal(data, 16, 8, false, true), [-128, 0]);
+	test.deepEqual(signals.decode_signal(data, 16, 16, false, true), [-32767, 0]);
+
+	// data = Buffer.from([0xFF, 0xFF, 0xFF, 0xFD, 0xDA, 0x3E, 0x82, 0xFB]);
+	// test.deepEqual(signals.decode_signal(data, 0, 64, false, true), [-9223372037, 0]);
 
 	test.done();
 }

--- a/tests/test-signal_conversion.js
+++ b/tests/test-signal_conversion.js
@@ -21,26 +21,30 @@ console.log(data);
 
 	signals.encode_signal(data, 12, 12, true, false, 0);
 	test.deepEqual(data, Buffer.from([0xAB, 0x0E, 0x00, 0, 0, 0, 0, 0]), "Overwriting signal value failed");
+
+	signals.encode_signal(data, 0, 64, true, false, 0xEFBEADDE, 0xBEBAFECA);
+	test.deepEqual(data, Buffer.from([0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE]));
 	test.done();
 }
 
 exports['little_endian_decode'] = function(test) {
 	data = Buffer.from([0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE]);
 
-	test.equals(signals.decode_signal(data, 0, 8, true, false), 0xDE);
-	test.equals(signals.decode_signal(data, 0, 12, true, false), 0xDDE);
-	test.equals(signals.decode_signal(data, 0, 16, true, false), 0xADDE);
-	test.equals(signals.decode_signal(data, 0, 24, true, false), 0xBEADDE);
-	test.equals(signals.decode_signal(data, 0, 32, true, false), 0xEFBEADDE);
+	test.deepEqual(signals.decode_signal(data, 0, 8, true, false), [0xDE, 0]);
+	test.deepEqual(signals.decode_signal(data, 0, 12, true, false), [0xDDE, 0]);
+	test.deepEqual(signals.decode_signal(data, 0, 16, true, false), [0xADDE, 0]);
+	test.deepEqual(signals.decode_signal(data, 0, 24, true, false), [0xBEADDE, 0]);
+	test.deepEqual(signals.decode_signal(data, 0, 32, true, false), [0xEFBEADDE, 0]);
+	test.deepEqual(signals.decode_signal(data, 0, 64, true, false), [0xEFBEADDE, 0xBEBAFECA]);
 
-	test.equals(signals.decode_signal(data, 12, 8, true, false), 0xEA);
-	test.equals(signals.decode_signal(data, 12, 12, true, false), 0xBEA);
-	test.equals(signals.decode_signal(data, 12, 20, true, false), 0xEFBEA);
+	test.deepEqual(signals.decode_signal(data, 12, 8, true, false), [0xEA, 0]);
+	test.deepEqual(signals.decode_signal(data, 12, 12, true, false), [0xBEA, 0]);
+	test.deepEqual(signals.decode_signal(data, 12, 20, true, false), [0xEFBEA, 0]);
 
-	test.equals(signals.decode_signal(data, 0, 1, true, false), 0);
-	test.equals(signals.decode_signal(data, 1, 1, true, false), 1);
-	test.equals(signals.decode_signal(data, 2, 1, true, false), 1);
-	test.equals(signals.decode_signal(data, 3, 1, true, false), 1);
+	test.deepEqual(signals.decode_signal(data, 0, 1, true, false), [0, 0]);
+	test.deepEqual(signals.decode_signal(data, 1, 1, true, false), [1, 0]);
+	test.deepEqual(signals.decode_signal(data, 2, 1, true, false), [1, 0]);
+	test.deepEqual(signals.decode_signal(data, 3, 1, true, false), [1, 0]);
 
 	test.done();
 }
@@ -48,12 +52,12 @@ exports['little_endian_decode'] = function(test) {
 exports['little_endian_signed_decode'] = function(test) {
 	data = Buffer.from([0xFE, 0xFF, 0x80]);
 
-	test.equals(signals.decode_signal(data, 8, 8, true, true), -1);
-	test.equals(signals.decode_signal(data, 0, 16, true, true), -2);
-	test.equals(signals.decode_signal(data, 16, 8, true, true), -128);
+	test.deepEqual(signals.decode_signal(data, 8, 8, true, true), [-1, 0]);
+	test.deepEqual(signals.decode_signal(data, 0, 16, true, true), [-2, 0]);
+	test.deepEqual(signals.decode_signal(data, 16, 8, true, true), [-128, 0]);
 
 	data = Buffer.from([0xFF, 0xFF, 0xFF, 0xFF]);
-	test.equals(signals.decode_signal(data, 0, 32, true, true), -1);
+  test.deepEqual(signals.decode_signal(data, 0, 32, true, true), [-1, 0]);
 
 	test.done();
 }
@@ -91,22 +95,25 @@ exports['big_endian_encode'] = function(test) {
 	signals.encode_signal(data, 12, 12, false, false, 0);
 	test.deepEqual(data, Buffer.from([0xDE, 0xA0, 0x00, 0, 0, 0, 0, 0]), "Overwriting signal value failed");
 
+	signals.encode_signal(data, 0, 64, false, false, 0xCAFEBABE, 0xDEADBEEF);
+	test.deepEqual(data, Buffer.from([0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE]));
+
 	test.done();
 }
 
 exports['big_endian_decode'] = function(test) {
 	data = Buffer.from([0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE]);
 
-	test.equals(signals.decode_signal(data, 0, 8, false, false), 0xDE);
-	test.equals(signals.decode_signal(data, 0, 16, false, false), 0xDEAD);
+	test.deepEqual(signals.decode_signal(data, 0, 8, false, false), [0xDE, 0]);
+	test.deepEqual(signals.decode_signal(data, 0, 16, false, false), [0xDEAD, 0]);
 
-	test.equals(signals.decode_signal(data, 7, 8, false, false), 0x56);
-	test.equals(signals.decode_signal(data, 15, 16, false, false), 0xDF77);
+	test.deepEqual(signals.decode_signal(data, 7, 8, false, false), [0x56, 0]);
+	test.deepEqual(signals.decode_signal(data, 15, 16, false, false), [0xDF77, 0]);
 
-	test.equals(signals.decode_signal(data, 0, 1, false, false), 1);
-	test.equals(signals.decode_signal(data, 1, 1, false, false), 1);
-	test.equals(signals.decode_signal(data, 2, 1, false, false), 0);
-	test.equals(signals.decode_signal(data, 3, 1, false, false), 1);
+	test.deepEqual(signals.decode_signal(data, 0, 1, false, false), [1, 0]);
+	test.deepEqual(signals.decode_signal(data, 1, 1, false, false), [1, 0]);
+	test.deepEqual(signals.decode_signal(data, 2, 1, false, false), [0, 0]);
+	test.deepEqual(signals.decode_signal(data, 3, 1, false, false), [1, 0]);
 
 	test.done();
 }
@@ -129,9 +136,9 @@ exports['big_endian_signed_encode'] = function(test) {
 exports['big_endian_signed_decode'] = function(test) {
 	data = Buffer.from([0xFF, 0xFE, 0x80 ]);
 
-	test.equals(signals.decode_signal(data, 0, 8, false, true), -1);
-	test.equals(signals.decode_signal(data, 0, 16, false, true), -2);
-	test.equals(signals.decode_signal(data, 16, 8, false, true), -128);
+	test.deepEqual(signals.decode_signal(data, 0, 8, false, true), [-1, 0]);
+	test.deepEqual(signals.decode_signal(data, 0, 16, false, true), [-2, 0]);
+	test.deepEqual(signals.decode_signal(data, 16, 8, false, true), [-128, 0]);
 
 	test.done();
 }


### PR DESCRIPTION
This adds support for 64 bit values by splitting the 64 bit value into two 32 bit values at `_getvalue` and `_setvalue` level. Solves #58 

`_setvalue` has no API change as the upper 32 bit value is optional. `_getvalue` changes from a value return to an array of the two 32 bit values. This is not a user facing function however and the wrapper and tests have been changed to support this. 

In addition, I have changed `ToObject`, `ToString` and `GetFunction` calls to their Nan equivalent to support V8 API change for Node 12 #63 . Ref https://github.com/RuntimeTools/appmetrics/pull/576, https://github.com/astro/node-expat/pull/196/files