### PR TITLE
Added option to select protocol when creating a raw channel.

### DIFF
--- a/socketcan.js
+++ b/socketcan.js
@@ -31,7 +31,10 @@ var buffer = require('buffer');
  * @return {RawChannel} a new channel object or exception
  * @for exports
  */
-exports.createRawChannel = function(channel, timestamps) { return new can.RawChannel(channel, timestamps); }
+exports.createRawChannel = function(channel, timestamps, protocol)
+{
+	return new can.RawChannel(channel, timestamps, protocol);
+}
 
 //-----------------------------------------------------------------------------
 /**

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -102,9 +102,9 @@ public:
   }
 
 private:
-  explicit RawChannel(const char *name, bool timestamps = false) : m_Thread(0), m_Name(name), m_SocketFd(-1)
+  explicit RawChannel(const char *name, bool timestamps = false, int protocol = CAN_RAW) : m_Thread(0), m_Name(name), m_SocketFd(-1)
   {
-    m_SocketFd = socket(PF_CAN, SOCK_RAW, CAN_RAW);
+    m_SocketFd = socket(PF_CAN, SOCK_RAW, protocol);
     m_ThreadStopRequested = false;
     m_TimestampsSupported = timestamps;
 

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -183,7 +183,14 @@ private:
         timestamps = info[1]->IsTrue();
     }
 
-    RawChannel* hw = new RawChannel(*ascii, timestamps);
+    int protocol = CAN_RAW;
+    if (info.Length() >= 3)
+    {
+      if (info[2]->IsInt32())
+        protocol = info[2]->IntegerValue();
+    }
+    
+    RawChannel* hw = new RawChannel(*ascii, timestamps, protocol);
     hw->Wrap(info.This());
 
     CHECK_CONDITION(hw->IsValid(), "Error while creating channel");

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -170,6 +170,7 @@ private:
   static NAN_METHOD(New)
   {
     bool timestamps = false;
+    int protocol = CAN_RAW;
 
     CHECK_CONDITION(info.IsConstructCall(), "Must be called with new");
     CHECK_CONDITION(info.Length() >= 1, "Too few arguments");
@@ -183,7 +184,6 @@ private:
         timestamps = info[1]->IsTrue();
     }
 
-    int protocol = CAN_RAW;
     if (info.Length() >= 3)
     {
       if (info[2]->IsInt32())


### PR DESCRIPTION
Hi.

I have a target that requires me to select a different protocol instead of the default CAN_RAW that is presently used when opening a socket.

I have added the option to pass the protocol. This is a sole addition and it will not break existing implementations that are using your package. I think my use case is rather rare but since it just adds flexibility I wonder if you would consider pulling it in.

Thanks again for your effort creating and maintaining this.