### PR TITLE
Fixing deprecated `v8::Value::IntegerValue()` for Node v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "sebastian@sebastianhaas.info"
   },
   "description": "A SocketCAN abstraction layer for NodeJS.",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -188,7 +188,7 @@ private:
     if (info.Length() >= 3)
     {
       if (info[2]->IsInt32())
-        protocol = info[2]->IntegerValue();
+        protocol = info[2]->IntegerValue(Nan::GetCurrentContext()).FromJust();
     }
     
     RawChannel* hw = new RawChannel(*ascii, timestamps, protocol);


### PR DESCRIPTION
## Summary
- `v8::Value::IntegerValue()` deprecation fix made based on suggestion provided here: https://github.com/bcoin-org/bcrypto/issues/7. 
- Bumped version in `package.json` from `2.5.0` to `2.6.0` to trigger release to https://www.npmjs.com/package/socketcan

## Relevant Issues
Closes #71 
