### PR TITLE
Update to support CAN_FD frame

### DIFF
--- a/socketcan.js
+++ b/socketcan.js
@@ -247,6 +247,13 @@ function Message(desc)
     this.mux = desc.mux;
 
     /**
+     * Named information to inform that the frame is CAN_FD format .
+     * @attribute Boolean
+     * @final
+     */
+     this.canfd = desc.canfd;           //GT modif
+
+    /**
      * Named array of signals within this message. Accessible via index and name.
      * @attribute {Signal} signals
      * @final
@@ -366,7 +373,8 @@ DatabaseService.prototype.send = function (msg_name) {
         id: m.id,
         ext: m.ext,
         rtr: false,
-        data : (m.len > 0 && m.len < 8) ? Buffer.alloc(m.len) : Buffer.alloc(8)
+        //data : (m.len > 0 && m.len < 8) ? Buffer.alloc(m.len) : Buffer.alloc(8)
+        data : (m.len > 0 && m.len < 64) ? Buffer.alloc(m.len) : Buffer.alloc(64)         // gt modif for CANFD
     };
 
     canmsg.data.fill(0); // should be 0xFF for j1939 message def.
@@ -415,6 +423,7 @@ DatabaseService.prototype.send = function (msg_name) {
 
     this.channel.send(canmsg);
 }
+
 
 /**
  * @method parseNetworkDescription

--- a/socketcan.js
+++ b/socketcan.js
@@ -373,8 +373,7 @@ DatabaseService.prototype.send = function (msg_name) {
         id: m.id,
         ext: m.ext,
         rtr: false,
-        //data : (m.len > 0 && m.len < 8) ? Buffer.alloc(m.len) : Buffer.alloc(8)
-        data : (m.len > 0 && m.len < 64) ? Buffer.alloc(m.len) : Buffer.alloc(64)         // gt modif for CANFD
+        data : (m.len > 0 && m.len < 64) ? Buffer.alloc(m.len) : Buffer.alloc(64)         // for CANFD data buffer 64 bytes
     };
 
     canmsg.data.fill(0); // should be 0xFF for j1939 message def.

--- a/socketcan.js
+++ b/socketcan.js
@@ -251,7 +251,7 @@ function Message(desc)
      * @attribute Boolean
      * @final
      */
-     this.canfd = desc.canfd;           //GT modif
+     this.canfd = desc.canfd;  
 
     /**
      * Named array of signals within this message. Accessible via index and name.

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -70,11 +70,6 @@ using namespace v8;
  * @module CAN
  */
 
-/* TODO */
-// define the variable as Member of this instance and not as Global Variable
-// Need help to declare properly this variable
-int Flag_CANFD_Used=0;         // Add a global Flag to treat the information according the interface capability, see Init function
-
 //-----------------------------------------------------------------------------------------
 /**
  * A Raw channel to access a certain CAN channel (e.g. vcan0) via CAN messages.
@@ -84,6 +79,7 @@ class RawChannel : public Nan::ObjectWrap
 {
 private:
   static Nan::Persistent<v8::Function> constructor;
+  int Flag_CANFD_Used=0;         // Add a global Flag to treat the information according the interface capability, see Init function
 
 public:
   static NAN_MODULE_INIT(Init)

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -348,7 +348,9 @@ on_error:
 
     if (hw->m_NonBlockingSend)
       flags = MSG_DONTWAIT;
+
     int i = send(hw->m_SocketFd, &frame, sizeof(struct can_frame), flags);  
+
     info.GetReturnValue().Set(i);
   }
 

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -131,9 +131,8 @@ private:
       /* try to switch the socket into CAN FD mode */
       setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &canfd_on, sizeof(canfd_on));
     
-      if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) != 0) {
-            goto on_error;
-      }  
+      if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) != 0)
+        goto on_error;
       
       memset(&m_SocketAddr, 0, sizeof(m_SocketAddr));
       m_SocketAddr.can_family = PF_CAN;

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -79,7 +79,6 @@ class RawChannel : public Nan::ObjectWrap
 {
 private:
   static Nan::Persistent<v8::Function> constructor;
-  int m_IsCanFdUsed=0;         // Add a global Flag to treat the information according the interface capability, see Init function
 
 public:
   static NAN_MODULE_INIT(Init)
@@ -548,6 +547,7 @@ private:
 
   int m_SocketFd;
   struct sockaddr_can m_SocketAddr;
+  int m_IsCanFdUsed=0;
 
   bool m_ThreadStopRequested;
   bool m_TimestampsSupported;

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -333,7 +333,7 @@ on_error:
     CHECK_CONDITION(node::Buffer::HasInstance(dataArg), "Data field must be a Buffer");
 
     // Get frame data
-    frame.can_dlc = node::Buffer::Length(Nan::To<Object>(dataArg).ToLocalChecked());    
+    frame.can_dlc = node::Buffer::Length(Nan::To<Object>(dataArg).ToLocalChecked());
     memcpy(frame.data, node::Buffer::Data(Nan::To<Object>(dataArg).ToLocalChecked()), frame.can_dlc);
 
     { // set time stamp when sending data

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -127,11 +127,11 @@ private:
 
       // Configuration updated to use the CAN_FD 
       err_mask = CAN_ERR_MASK;
-      m_IsCanFdUsed = 1 ;                                                                               // try to use CAN_FD first
-      if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &canfd_on, sizeof(canfd_on)) != 0)        // configuration for CAN_FD
+      m_IsCanFdUsed = 1 ;
+      if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &canfd_on, sizeof(canfd_on)) != 0)        // switch socket to CANFD mode
       {
-        m_IsCanFdUsed = 0 ;                                                                               // CAN_FD not usable
-        if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) != 0)    // test for CAN_HS
+        m_IsCanFdUsed = 0 ;
+        if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) != 0)
           {
             goto on_error;
           }

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -349,7 +349,7 @@ on_error:
     if (hw->m_NonBlockingSend)
       flags = MSG_DONTWAIT;
 
-    int i = send(hw->m_SocketFd, &frame, sizeof(struct can_frame), flags);  
+    int i = send(hw->m_SocketFd, &frame, sizeof(struct can_frame), flags);
 
     info.GetReturnValue().Set(i);
   }

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -683,8 +683,8 @@ private:
     
     unsigned int framesProcessed = 0;
     
-    if (m_IsCanFdUsed){               // standard CAN frame
-      while (recv(m_SocketFd, &framefd, sizeof(struct canfd_frame), MSG_DONTWAIT) > 0)      // go modif : use CAN_FD struct
+    if (m_IsCanFdUsed){
+      while (recv(m_SocketFd, &framefd, sizeof(struct canfd_frame), MSG_DONTWAIT) > 0)
       {
         Nan::TryCatch try_catch;
 

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -471,6 +471,7 @@ on_error:
 
     if (numfilter)
       setsockopt(hw->m_SocketFd, SOL_CAN_RAW, CAN_RAW_FILTER, rfilter, numfilter * sizeof(struct can_filter));
+    
     if (rfilter)
       free(rfilter);
 

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -125,12 +125,11 @@ private:
       if (ioctl(m_SocketFd, SIOCGIFINDEX, &ifr) != 0)
         goto on_error;
 
-      // Configuration updated to use the CAN_FD 
       err_mask = CAN_ERR_MASK;
 
       /* try to switch the socket into CAN FD mode */
       setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &canfd_on, sizeof(canfd_on));
-    
+
       if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) != 0)
         goto on_error;
 
@@ -148,7 +147,7 @@ private:
 
       return;
 
-    on_error:
+      on_error:
       close(m_SocketFd);
       m_SocketFd = -1;
     }

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -320,8 +320,8 @@ on_error:
     v8::Local<v8::Object> obj = Nan::To<Object>(info[0]).ToLocalChecked();
 
     // TODO: Check for correct structure of message object
-
     frame.can_id = obj->Get(context, id_symbol).ToLocalChecked()->ToUint32(context).ToLocalChecked()->Value();
+
     if (obj->Get(context, ext_symbol).ToLocalChecked()->IsTrue())
       frame.can_id |= CAN_EFF_FLAG;
 

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -321,33 +321,33 @@ on_error:
 
     // TODO: Check for correct structure of message object
 
-      frame.can_id = obj->Get(context, id_symbol).ToLocalChecked()->ToUint32(context).ToLocalChecked()->Value();
-      if (obj->Get(context, ext_symbol).ToLocalChecked()->IsTrue())
-        frame.can_id |= CAN_EFF_FLAG;
+    frame.can_id = obj->Get(context, id_symbol).ToLocalChecked()->ToUint32(context).ToLocalChecked()->Value();
+    if (obj->Get(context, ext_symbol).ToLocalChecked()->IsTrue())
+      frame.can_id |= CAN_EFF_FLAG;
 
-      if (obj->Get(context, rtr_symbol).ToLocalChecked()->IsTrue())
-        frame.can_id |= CAN_RTR_FLAG;
+    if (obj->Get(context, rtr_symbol).ToLocalChecked()->IsTrue())
+      frame.can_id |= CAN_RTR_FLAG;
 
-      v8::Local<v8::Value> dataArg = obj->Get(context, data_symbol).ToLocalChecked();
+    v8::Local<v8::Value> dataArg = obj->Get(context, data_symbol).ToLocalChecked();
 
-      CHECK_CONDITION(node::Buffer::HasInstance(dataArg), "Data field must be a Buffer");
+    CHECK_CONDITION(node::Buffer::HasInstance(dataArg), "Data field must be a Buffer");
 
-      // Get frame data
-      frame.can_dlc = node::Buffer::Length(Nan::To<Object>(dataArg).ToLocalChecked());    
-      memcpy(frame.data, node::Buffer::Data(Nan::To<Object>(dataArg).ToLocalChecked()), frame.can_dlc);
+    // Get frame data
+    frame.can_dlc = node::Buffer::Length(Nan::To<Object>(dataArg).ToLocalChecked());    
+    memcpy(frame.data, node::Buffer::Data(Nan::To<Object>(dataArg).ToLocalChecked()), frame.can_dlc);
 
-      { // set time stamp when sending data
-        struct timeval now;
-        if ( 0==gettimeofday(&now, 0)) {
-          Nan::Set(obj, tssec_symbol, Nan::New((int32_t)now.tv_sec));
-          Nan::Set(obj, tsusec_symbol, Nan::New((int32_t)now.tv_usec));
-        }
+    { // set time stamp when sending data
+      struct timeval now;
+      if ( 0==gettimeofday(&now, 0)) {
+        Nan::Set(obj, tssec_symbol, Nan::New((int32_t)now.tv_sec));
+        Nan::Set(obj, tsusec_symbol, Nan::New((int32_t)now.tv_usec));
       }
+    }
 
-      int flags = 0;
+    int flags = 0;
 
-      if (hw->m_NonBlockingSend)
-        flags = MSG_DONTWAIT;
+    if (hw->m_NonBlockingSend)
+      flags = MSG_DONTWAIT;
     int i = send(hw->m_SocketFd, &frame, sizeof(struct can_frame), flags);  
     info.GetReturnValue().Set(i);
   }

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -69,6 +69,10 @@ using namespace v8;
  * Basic CAN & CAN_FD access
  * @module CAN
  */
+
+/* TODO */
+// define the variable as Member of this instance and not as Global Variable
+// Need help to declare properly this variable
 static int Flag_CANFD_Used=0;         // Add a global Flag to treat the information according the interface capability, see Init function
 
 //-----------------------------------------------------------------------------------------

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -73,7 +73,7 @@ using namespace v8;
 /* TODO */
 // define the variable as Member of this instance and not as Global Variable
 // Need help to declare properly this variable
-static int Flag_CANFD_Used=0;         // Add a global Flag to treat the information according the interface capability, see Init function
+int Flag_CANFD_Used=0;         // Add a global Flag to treat the information according the interface capability, see Init function
 
 //-----------------------------------------------------------------------------------------
 /**

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -19,10 +19,6 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
- 
- /*
-  * 
-  */
 
 #include <nan.h>
 #include <node_buffer.h>
@@ -73,7 +69,7 @@ using namespace v8;
  * Basic CAN & CAN_FD access
  * @module CAN
  */
-static int Flag_CANFD_Used=0;         // GT modif : Add a global Flag to treat the information according the interface capability, see Init function
+static int Flag_CANFD_Used=0;         // Add a global Flag to treat the information according the interface capability, see Init function
 
 //-----------------------------------------------------------------------------------------
 /**
@@ -100,7 +96,7 @@ public:
     Nan::SetPrototypeMethod(tpl, "start",           Start);
     Nan::SetPrototypeMethod(tpl, "stop",            Stop);
     Nan::SetPrototypeMethod(tpl, "send",            Send);
-    Nan::SetPrototypeMethod(tpl, "sendFD",          SendFD);                  // GT MODIF : add function for SEND_CANFD frame
+    Nan::SetPrototypeMethod(tpl, "sendFD",          SendFD);                  //add dedicate function for SEND_CANFD frame
     Nan::SetPrototypeMethod(tpl, "setRxFilters",    SetRxFilters);
     Nan::SetPrototypeMethod(tpl, "setErrorFilters", SetErrorFilters);
     Nan::SetPrototypeMethod(tpl, "disableLoopback", DisableLoopback);
@@ -132,11 +128,11 @@ private:
 
       // Configuration updated to use the CAN_FD 
       err_mask = CAN_ERR_MASK;
-      Flag_CANFD_Used = 1 ;                                                                               // GT MODIF : try to use CAN_FD first
-      if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES,&canfd_on, sizeof(canfd_on)) != 0)        // GT MODIF : configuration for CAN_FD
+      Flag_CANFD_Used = 1 ;                                                                               // try to use CAN_FD first
+      if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES,&canfd_on, sizeof(canfd_on)) != 0)        // configuration for CAN_FD
       {
-        Flag_CANFD_Used = 0 ;                                                                               // GT MODIF : CAN_FD not usable
-        if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) != 0)          // GT MODIF : configuration for CAN_HS
+        Flag_CANFD_Used = 0 ;                                                                               // CAN_FD not usable
+        if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) != 0)      // So use the configuration for CAN_HS
           {
             goto on_error;
           }
@@ -320,7 +316,6 @@ on_error:
    */
   static NAN_METHOD(Send)
   {
-    int requiered_mtu = 1;
     RawChannel* hw = ObjectWrap::Unwrap<RawChannel>(info.Holder());
 
     CHECK_CONDITION(info.Length() >= 1, "Invalid arguments");

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -324,8 +324,6 @@ on_error:
     v8::Local<v8::Context> context = info.GetIsolate()->GetCurrentContext();
     v8::Local<v8::Object> obj = Nan::To<Object>(info[0]).ToLocalChecked();
 
-    // CAN HS FRAME
-    // ---------------
     // TODO: Check for correct structure of message object
 
       frame.can_id = obj->Get(context, id_symbol).ToLocalChecked()->ToUint32(context).ToLocalChecked()->Value();

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -110,7 +110,7 @@ private:
   explicit RawChannel(const char *name, bool timestamps, int protocol, bool non_block_send)
     : m_Thread(0), m_Name(name), m_SocketFd(-1)
   {
-    static const int canfd_on = 1;
+    const int canfd_on = 1;
     m_SocketFd = socket(PF_CAN, SOCK_RAW, protocol);
     m_ThreadStopRequested = false;
     m_TimestampsSupported = timestamps;
@@ -129,7 +129,7 @@ private:
       // Configuration updated to use the CAN_FD 
       err_mask = CAN_ERR_MASK;
       m_IsCanFdUsed = 1 ;                                                                               // try to use CAN_FD first
-      if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES,&canfd_on, sizeof(canfd_on)) != 0)        // configuration for CAN_FD
+      if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &canfd_on, sizeof(canfd_on)) != 0)        // configuration for CAN_FD
       {
         m_IsCanFdUsed = 0 ;                                                                               // CAN_FD not usable
         if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) != 0)      // So use the configuration for CAN_HS

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -69,7 +69,7 @@ using namespace v8;
  * Basic CAN & CAN_FD access
  * @module CAN
  */
-private static int Flag_CANFD_Used=0;         // Add a global Flag to treat the information according the interface capability, see Init function
+static int Flag_CANFD_Used=0;         // Add a global Flag to treat the information according the interface capability, see Init function
 
 //-----------------------------------------------------------------------------------------
 /**

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -466,7 +466,7 @@ on_error:
 
     if (numfilter)
       setsockopt(hw->m_SocketFd, SOL_CAN_RAW, CAN_RAW_FILTER, rfilter, numfilter * sizeof(struct can_filter));
-    
+
     if (rfilter)
       free(rfilter);
 

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -358,7 +358,7 @@ on_error:
   }
 
  /**
-   * Send a CAN message immediately.
+   * Send a CAN_FD message immediately.
    *
    * PLEASE NOTE: By default, this function may block if the Tx buffer is not available. Please use
    * createRawChannelWithOptions({non_block_send: false}) to get non-blocking sending activated.

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -366,7 +366,7 @@ on_error:
    * Note : All the setup is not supported and no protection are included
    * 
    * @method send
-   * @param message {Object} JSON object describing the CAN message, keys are id, length, data {Buffer}, ext or rtr
+   * @param message {Object} JSON object describing the CAN message, keys are id, length, data {Buffer}, ext
    */
   static NAN_METHOD(SendFD)
   {

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -363,7 +363,6 @@ on_error:
    * PLEASE NOTE: By default, this function may block if the Tx buffer is not available. Please use
    * createRawChannelWithOptions({non_block_send: false}) to get non-blocking sending activated.
    *
-   * Added by Guillaume Tournabien 2021_03_14
    * Note : All the setup is not supported and no protection are included
    * 
    * @method send
@@ -419,7 +418,8 @@ on_error:
     if ( frameFD.len > 64) 
       frameFD.len = 64;
     frameFD.len = len2dlc[frameFD.len];
-
+    
+    int flags = 0;
     if (hw->m_NonBlockingSend)
       flags = MSG_DONTWAIT;
     int i = send(hw->m_SocketFd,&frameFD,sizeof(struct canfd_frame),flags); 

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -492,7 +492,7 @@ on_error:
 
     can_err_mask_t err_mask = (can_err_mask_t) info[0]->ToUint32(context).ToLocalChecked()->Value();
 
-    setsockopt(hw->m_SocketFd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);  
+    setsockopt(hw->m_SocketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask));
     info.GetReturnValue().Set(info.This());
   }
 

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -470,7 +470,7 @@ on_error:
     }
 
     if (numfilter)
-      setsockopt(hw->m_SocketFd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);  
+      setsockopt(hw->m_SocketFd, SOL_CAN_RAW, CAN_RAW_FILTER, rfilter, numfilter * sizeof(struct can_filter));
     if (rfilter)
       free(rfilter);
 

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -133,7 +133,7 @@ private:
     
       if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) != 0)
         goto on_error;
-      
+
       memset(&m_SocketAddr, 0, sizeof(m_SocketAddr));
       m_SocketAddr.can_family = PF_CAN;
       m_SocketAddr.can_ifindex = ifr.ifr_ifindex;

--- a/src/rawchannel.cc
+++ b/src/rawchannel.cc
@@ -131,7 +131,7 @@ private:
       if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_FD_FRAMES, &canfd_on, sizeof(canfd_on)) != 0)        // configuration for CAN_FD
       {
         m_IsCanFdUsed = 0 ;                                                                               // CAN_FD not usable
-        if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) != 0)      // So use the configuration for CAN_HS
+        if (setsockopt(m_SocketFd, SOL_CAN_RAW, CAN_RAW_ERR_FILTER, &err_mask, sizeof(err_mask)) != 0)    // test for CAN_HS
           {
             goto on_error;
           }
@@ -505,7 +505,7 @@ on_error:
     RawChannel* hw = ObjectWrap::Unwrap<RawChannel>(info.Holder());
     CHECK_CONDITION(hw->IsValid(), "Channel not ready");
     const int loopback = 0;
-    setsockopt(hw->m_SocketFd, SOL_CAN_RAW, CAN_RAW_FILTER, NULL, 0);
+    setsockopt(hw->m_SocketFd, SOL_CAN_RAW, CAN_RAW_LOOPBACK, &loopback, sizeof(loopback));
     info.GetReturnValue().Set(info.This());
   }
 

--- a/src/signals.cc
+++ b/src/signals.cc
@@ -100,7 +100,8 @@ NAN_METHOD(DecodeSignal)
     u_int32_t offset, bitLength;
     ENDIANESS endianess;
     bool isSigned = false;
-    u_int8_t data[8];
+    //u_int8_t data[8];
+    u_int8_t data[64];           // GT modif : CANFD size of bufer = 64
 
     CHECK_CONDITION(info.Length() == 5, "Too few arguments");
     CHECK_CONDITION(info[0]->IsObject(), "Invalid argument");
@@ -209,7 +210,8 @@ NAN_METHOD(EncodeSignal)
 {
     u_int32_t offset, bitLength;
     ENDIANESS endianess;
-    u_int8_t data[8];
+    //u_int8_t data[8];
+    u_int8_t data[64];           // GT modif : CANFD size of bufer = 64
     u_int64_t raw_value;
 
     CHECK_CONDITION(info.Length() >= 6, "Too few arguments");

--- a/src/signals.cc
+++ b/src/signals.cc
@@ -100,8 +100,7 @@ NAN_METHOD(DecodeSignal)
     u_int32_t offset, bitLength;
     ENDIANESS endianess;
     bool isSigned = false;
-    //u_int8_t data[8];
-    u_int8_t data[64];           // GT modif : CANFD size of bufer = 64
+    u_int8_t data[64];           // CANFD size of bufer = 64
 
     CHECK_CONDITION(info.Length() == 5, "Too few arguments");
     CHECK_CONDITION(info[0]->IsObject(), "Invalid argument");
@@ -210,8 +209,7 @@ NAN_METHOD(EncodeSignal)
 {
     u_int32_t offset, bitLength;
     ENDIANESS endianess;
-    //u_int8_t data[8];
-    u_int8_t data[64];           // GT modif : CANFD size of bufer = 64
+    u_int8_t data[64];           // CANFD size of bufer = 64
     u_int64_t raw_value;
 
     CHECK_CONDITION(info.Length() >= 6, "Too few arguments");


### PR DESCRIPTION
HEllo
I updated the library to support the CAN_FD frames & drivers.
The received messages are not able to support 64 bytes.

To be able to work with standard CAN (current version), I create a dedicated send_FD() function dedicated to CAN_FD.
So there is no impact with the current version but offer to use long frame (>8) if your interface support the CAN_FD.

Those modification are mandatory to use after the node-red-contrib-socketcan into node red.
By default the OpenCom will try to see if the interface support the CAN_FD, if yes the buffer will be bigger based on the frameFD Struct. If not the standard frame is used.

Hope that will be the beginning of new node_red function. 
Modification tested and used on my project with PEAK 6x CAN_FD interface. Tested also in multichannel configuration (3 channels CAN0, CAN1 & CAN2) without any troubles.

Regards