### PR TITLE
compile the TS before publishing

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -19,8 +19,10 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 14
-      - run: npm i -g npm
-      - run: npm ci
+      - run: |
+          npm i -g npm
+          npm ci
+          npm build:ts
       - uses: JS-DevTools/npm-publish@v1
         with:
           dry-run: true


### PR DESCRIPTION
this PR has the publish workflow compile the TS code before publishing - the `dist/` directory (of compiled js files) is currently not in the 4.0pre tarball. This should fix that.