### PR TITLE
include binding.gyp, explicitly build native

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:ts": "tsc",
     "build:all": "npm run build && npm run build:ts",
     "lint": "eslint --fix '*/**/*.{js,ts}'",
+    "install": "node-gyp rebuild",
     "test": "mocha"
   },
   "devDependencies": {
@@ -25,7 +26,6 @@
     "@typescript-eslint/eslint-plugin": "5.42.0",
     "@typescript-eslint/parser": "5.42.0",
     "mocha": "10.1.0",
-    "node-gyp": ">=9.3.0",
     "nyc": "^15.0.1",
     "typescript": "4.8.4",
     "eslint": "8.27.0",
@@ -35,10 +35,18 @@
   },
   "dependencies": {
     "nan": "*",
+    "node-gyp": ">=9.3.0",
     "xml2js": ">=0.2.0"
   },
   "main": "dist/socketcan.js",
-  "files": [ "dist", "samples", "src", "native", "docs" ],
+  "files": [
+    "binding.gyp",
+    "dist",
+    "samples",
+    "src",
+    "native",
+    "docs"
+  ],
   "os": [
     "linux"
   ]


### PR DESCRIPTION
this does three things:

* include `binding.gyp` in the package - my mistake and should have been included originally
* makes node-gyp an explicit dependency, so package consumers can compile locally w/o needing to depend on it themselves
* makes building the native code an explicit step during installation - this is optional, as the inclusion of binding.gyp makes it implicit, but this seems safer.

I am using yarn on my downstream project and don't seem to understand how to force yarn to update local packages, but I created an empty npm package that depends on the local pack of this branch and the install correctly built the `build/` directory.

I will need to test actually functionality over the canbus later, hopefully this evening (EST)