### PR TITLE
Added possibility to set BRS flag in SendFD

### DIFF
--- a/native/can.cc
+++ b/native/can.cc
@@ -64,7 +64,8 @@ using namespace v8;
 #define rtr_symbol      SYMBOL("rtr")
 #define err_symbol      SYMBOL("err")
 #define data_symbol     SYMBOL("data")
-#define canfd_symbol    SYMBOL("canfd")        
+#define canfd_symbol    SYMBOL("canfd")
+#define fdbrs_symbol    SYMBOL("fd_brs")
 
 /**
  * Basic CAN & CAN_FD access
@@ -375,7 +376,7 @@ on_error:
     CHECK_CONDITION(info[0]->IsObject(), "First argument must be an Object");
     CHECK_CONDITION(hw->IsValid(), "Invalid channel!");
     struct canfd_frame frameFD;                         
-    frameFD.flags = 0; // Flags not used in this function
+    frameFD.flags = 0;
 
     v8::Local<v8::Context> context = info.GetIsolate()->GetCurrentContext();
     v8::Local<v8::Object> obj = Nan::To<Object>(info[0]).ToLocalChecked();
@@ -384,6 +385,9 @@ on_error:
 
     if (obj->Get(context, ext_symbol).ToLocalChecked()->IsTrue())
       frameFD.can_id  |= CAN_EFF_FLAG;
+
+    if (obj->Get(context, fdbrs_symbol).ToLocalChecked()->IsTrue())
+      frameFD.flags |= CANFD_BRS;
 
     v8::Local<v8::Value> dataArg = obj->Get(context, data_symbol).ToLocalChecked();
 


### PR DESCRIPTION
Hi,

as a continuation of PR #106, I've re-synchronized my fork by latest version of node-can (PR #106 automatically closed), re-implemented the new code according to what was discussed and created this new PR.

Now, the new symbol for bitrate switching is called "fd_brs" and is boolean.
If set, the CANFD_BRS (defined in socket can kernel headers) is added to frameFD.flags when transmitting CAN-FD frame in SendFD method. This will allow users of node-can to perform bitrate switching in CAN-FD frames.
It's backward compatible. If no "fd_brs" symbol is existing, the frameFD.flags will be of value 0, as hardcoded before.

As discussed with @sebi2k1, this new feature is available in native only for now (proper integration of KCD is separated).

Thank you for possible acceptation of this PR and have a nice day!

Martin