### PR TITLE
Fix #116 by referencing ambient declarations

### DIFF
--- a/src/parse_kcd.ts
+++ b/src/parse_kcd.ts
@@ -150,6 +150,7 @@ function makeSignalFromXml(
 	if (Array.isArray(labelset)) {
 		const rawLabels = labelset[0]["Label"];
 		if (rawLabels != undefined) {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			rawLabels.forEach((l: any) => {
 				labelSet[l["$"].value] = l["$"].name;
 			});

--- a/src/socketcan.ts
+++ b/src/socketcan.ts
@@ -22,6 +22,7 @@
 // -----------------------------------------------------------------------------
 // CAN-Object
 
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="./can.d.ts" />
 import * as can from "../build/Release/can.node";
 
@@ -31,6 +32,7 @@ import * as can from "../build/Release/can.node";
  * encoded in CAN messages.
  * @module Signals
  */
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="./can_signals.d.ts" />
 import * as _signals from "../build/Release/can_signals.node";
 

--- a/src/socketcan.ts
+++ b/src/socketcan.ts
@@ -22,6 +22,7 @@
 // -----------------------------------------------------------------------------
 // CAN-Object
 
+/// <reference path="./can.d.ts" />
 import * as can from "../build/Release/can.node";
 
 // -----------------------------------------------------------------------------
@@ -30,6 +31,7 @@ import * as can from "../build/Release/can.node";
  * encoded in CAN messages.
  * @module Signals
  */
+/// <reference path="./can_signals.d.ts" />
 import * as _signals from "../build/Release/can_signals.node";
 
 // import * as _signals from "can_signals";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "ES2021",
     "lib": ["ESNext"],
     "allowJs": false,
-    "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,


### PR DESCRIPTION
This change fixes #116 by referencing the ambient declarations used by the library itself. This ensures the TS declarations for the node-gyp files are exported by the library and available to downstream projects.

Apologies for the oversight!

Let me know if you have any questions about these changes.

Sidenote: you may want to run `lint` before the compile steps in your GitHub workflows - builds will be faster when there are linting errors (which typically come before the TS compilation errors).