### PR TITLE
Add err boolean type to can.d.ts Message

### DIFF
--- a/src/can.d.ts
+++ b/src/can.d.ts
@@ -4,7 +4,7 @@ declare module "*can.node" {
 		ext: boolean;
 		rtr: boolean;
 		data: Buffer;
-		err: boolean;
+		err?: boolean;
 	}
 
 	export class RawChannel {

--- a/src/can.d.ts
+++ b/src/can.d.ts
@@ -4,6 +4,7 @@ declare module "*can.node" {
 		ext: boolean;
 		rtr: boolean;
 		data: Buffer;
+		err: boolean;
 	}
 
 	export class RawChannel {


### PR DESCRIPTION
Helps with https://github.com/sebi2k1/node-can/issues/133 (not sure why it was closed, out of scope?) and avoids a `// @ts-ignore` in my code.
