### PR TITLE
fix(can.cc): use napi_make_callback to restore microtask draining between onMessage callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [4.1.0] - 2026-05-17
 
+### Fixed
+- **Regression vs 4.0.7**: `onMessage` callbacks are now invoked via
+  `napi_make_callback` instead of plain `napi_call_function`. This restores
+  the behaviour of the old NaN implementation, which called
+  `node::MakeCallback` (and therefore ran a microtask checkpoint and fired
+  async hooks after each callback). Without this, adapters that queue work
+  via Promises or `setImmediate` inside `onMessage` could not keep up with
+  incoming frames, producing "evaluation overloaded" warnings and "bad frame"
+  errors (reported against ioBroker.e3oncan).
+- Exceptions thrown by `onMessage` or `onStopped` callbacks are now forwarded
+  to Node.js via `napi_fatal_exception` (matching the old `Nan::FatalException`
+  behaviour) instead of being silently dropped with the JS exception left
+  pending, which could corrupt subsequent frame objects.
+
 ### Changed
 - Migrated native addon from `nan` to `node-addon-api` (N-API). The binary
   is now ABI-stable across Node.js major versions: a module compiled for

--- a/native/can.cc
+++ b/native/can.cc
@@ -97,7 +97,7 @@ public:
     : Napi::ObjectWrap<RawChannel>(info),
       m_Thread(0), m_Name(""), m_ReadPending(false), m_SocketFd(-1),
       m_ThreadStopRequested(false), m_TimestampsSupported(false),
-      m_NonBlockingSend(false), m_napi_env(nullptr)
+      m_NonBlockingSend(false), m_napi_env(nullptr), m_async_ctx(nullptr)
   {
     Napi::Env env = info.Env();
 
@@ -247,6 +247,13 @@ private:
 
     uv_async_init(loop, &m_AsyncChannelStopped, async_channel_stopped_cb);
     m_AsyncChannelStopped.data = this;
+
+    // Create an async context so napi_make_callback runs microtask checkpoints
+    // and fires async hooks after each onMessage callback, matching the behaviour
+    // of the old NaN implementation (which used node::MakeCallback internally).
+    napi_value resource_name;
+    napi_create_string_utf8(env, "socketcan:RawChannel:onMessage", NAPI_AUTO_LENGTH, &resource_name);
+    napi_async_init(env, (napi_value)info.This(), resource_name, &m_async_ctx);
 
     m_ThreadStopRequested = false;
     pthread_create(&m_Thread, NULL, c_thread_entry, this);
@@ -500,6 +507,7 @@ private:
 
   // Stored for use in uv_async callbacks (always invoked on the main thread)
   napi_env m_napi_env;
+  napi_async_context m_async_ctx;
 
   static void * c_thread_entry(void *_this) { assert(_this); reinterpret_cast<RawChannel *>(_this)->ThreadEntry(); return NULL; }
 
@@ -592,8 +600,12 @@ private:
       else
         fn.Call(l->handle.Value(), {});
 
-      if (env.IsExceptionPending())
+      if (env.IsExceptionPending()) {
+        napi_value exception;
+        napi_get_and_clear_last_exception(env, &exception);
+        napi_fatal_exception(env, exception);
         break;
+      }
     }
 
     if (m_Thread)
@@ -603,11 +615,18 @@ private:
       uv_close((uv_handle_t *)&m_AsyncChannelStopped, NULL);
     }
 
+    if (m_async_ctx) {
+      napi_async_destroy(m_napi_env, m_async_ctx);
+      m_async_ctx = nullptr;
+    }
+
     Unref();
   }
 
   void async_receiver_ready()
   {
+    if (!m_async_ctx) return;
+
     Napi::Env env(m_napi_env);
     Napi::HandleScope scope(env);
 
@@ -643,21 +662,33 @@ private:
 
       obj.Set("data", Napi::Buffer<char>::Copy(env, (char *)frame.data, frame.len & 0x7f));
 
+      bool callback_failed = false;
       for (size_t i = 0; i < m_OnMessageListeners.size(); i++)
       {
         struct listener *l = m_OnMessageListeners.at(i);
-        Napi::Function fn = l->callback.Value();
 
-        if (l->handle.IsEmpty())
-          fn.Call(env.Global(), {obj});
-        else
-          fn.Call(l->handle.Value(), {obj});
+        // Use napi_make_callback instead of plain fn.Call() so that
+        // Node.js runs a microtask checkpoint and fires async hooks
+        // after each invocation, matching the old NaN behaviour
+        // (Nan::Callback::Call used node::MakeCallback internally).
+        napi_value recv_val = l->handle.IsEmpty()
+            ? (napi_value)env.Global()
+            : (napi_value)l->handle.Value();
+        napi_value fn_val   = (napi_value)l->callback.Value();
+        napi_value arg      = (napi_value)obj;
+        napi_value result;
+        napi_make_callback(env, m_async_ctx, recv_val, fn_val, 1, &arg, &result);
 
-        if (env.IsExceptionPending())
+        if (env.IsExceptionPending()) {
+          napi_value exception;
+          napi_get_and_clear_last_exception(env, &exception);
+          napi_fatal_exception(env, exception);
+          callback_failed = true;
           break;
+        }
       }
 
-      if (env.IsExceptionPending())
+      if (callback_failed)
         break;
 
       if (++framesProcessed > MAX_FRAMES_PER_ASYNC_EVENT)

--- a/test/test-callback_ordering.js
+++ b/test/test-callback_ordering.js
@@ -1,0 +1,111 @@
+'use strict';
+
+// Regression test for the napi_make_callback fix (4.1.0).
+//
+// The old N-API implementation called fn.Call() → napi_call_function(), which
+// does NOT run a microtask checkpoint between callbacks.  The NaN
+// implementation used Nan::Callback::Call() → node::MakeCallback(), which
+// DOES run a microtask checkpoint (and fires async hooks) after each call.
+//
+// Without the checkpoint, adapters that queue work via Promises or
+// setImmediate inside onMessage fall behind: when 100 frames arrive in one
+// uv_async batch, all 100 JS callbacks fire back-to-back with no chance for
+// Promise continuations to run, overwhelming any async processing queue.
+//
+// This test sends a batch of frames (fewer than MAX_FRAMES_PER_ASYNC_EVENT so
+// they all land in one uv_async invocation) and verifies that the microtask
+// scheduled by callback N has resolved before callback N+1 fires.
+
+var assert = require('assert');
+var can    = require('../dist/socketcan');
+
+describe('RawChannel callback ordering', function() {
+    it('should drain microtasks between consecutive onMessage callbacks', function(done) {
+        var c_rx = can.createRawChannelWithOptions('vcan0', {});
+        var c_tx = can.createRawChannelWithOptions('vcan0', { non_block_send: true });
+
+        c_rx.start();
+        c_tx.start();
+
+        var syncCount      = 0;    // incremented synchronously in each callback
+        var asyncCount     = 0;    // incremented by a resolved Promise (microtask)
+        var interleavingOk = true;
+        var TOTAL          = 30;   // safely below MAX_FRAMES_PER_ASYNC_EVENT (100)
+
+        c_rx.addListener('onMessage', function(msg) {
+            // With napi_make_callback a microtask checkpoint runs after every
+            // callback, so the Promise queued by the previous callback has
+            // already resolved when we get here.  asyncCount must therefore
+            // equal syncCount for every call after the first.
+            if (syncCount > 0 && asyncCount !== syncCount) {
+                interleavingOk = false;
+            }
+            syncCount++;
+            // Microtask: resolved Promise continuation.
+            Promise.resolve().then(function() { asyncCount++; });
+        });
+
+        var frame = { id: 0x200, data: Buffer.alloc(1) };
+        for (var i = 0; i < TOTAL; i++) {
+            frame.data[0] = i & 0xFF;
+            c_tx.send(frame);
+        }
+
+        setTimeout(function() {
+            c_rx.stop();
+            c_tx.stop();
+
+            assert.strictEqual(syncCount, TOTAL, 'should receive all frames synchronously');
+            assert.strictEqual(asyncCount, TOTAL, 'all Promise continuations should have run');
+            assert.ok(
+                interleavingOk,
+                'napi_make_callback must drain microtasks between callbacks; ' +
+                'got asyncCount=' + asyncCount + ' syncCount=' + syncCount
+            );
+            done();
+        }, 500);
+    });
+
+    it('should drain process.nextTick between consecutive onMessage callbacks', function(done) {
+        var c_rx = can.createRawChannelWithOptions('vcan0', {});
+        var c_tx = can.createRawChannelWithOptions('vcan0', { non_block_send: true });
+
+        c_rx.start();
+        c_tx.start();
+
+        var syncCount      = 0;
+        var tickCount      = 0;
+        var interleavingOk = true;
+        var TOTAL          = 30;
+
+        c_rx.addListener('onMessage', function(msg) {
+            // process.nextTick callbacks are drained before Promise microtasks;
+            // they must also run between callbacks when napi_make_callback is used.
+            if (syncCount > 0 && tickCount !== syncCount) {
+                interleavingOk = false;
+            }
+            syncCount++;
+            process.nextTick(function() { tickCount++; });
+        });
+
+        var frame = { id: 0x201, data: Buffer.alloc(1) };
+        for (var i = 0; i < TOTAL; i++) {
+            frame.data[0] = i & 0xFF;
+            c_tx.send(frame);
+        }
+
+        setTimeout(function() {
+            c_rx.stop();
+            c_tx.stop();
+
+            assert.strictEqual(syncCount, TOTAL, 'should receive all frames synchronously');
+            assert.strictEqual(tickCount,  TOTAL, 'all nextTick callbacks should have run');
+            assert.ok(
+                interleavingOk,
+                'process.nextTick must run between callbacks; ' +
+                'got tickCount=' + tickCount + ' syncCount=' + syncCount
+            );
+            done();
+        }, 500);
+    });
+});


### PR DESCRIPTION
## Problem

Users of socketcan 4.1.0 (the N-API migration) see two symptoms compared to 4.0.7 (NaN) when using adapters like ioBroker.e3oncan on a busy CAN bus:

1. **Constant "Bad frame" warnings** during normal operation
2. **"Evaluation of messages overloaded. Counter=400"** — the adapter's async processing queue fills faster than it drains

Both symptoms disappear immediately on downgrade to 4.0.7.

## Root cause

The NaN implementation called `Nan::Callback::Call()` which routes through `node::MakeCallback()`. That function wraps every callback in a `node::InternalCallbackScope` whose destructor runs a **microtask checkpoint** (drains Promises and `process.nextTick`) and fires `before`/`after` async hooks.

The N-API migration replaced this with `fn.Call()` → `napi_call_function()`, which skips both steps.

On a busy bus, the `uv_async_t` batch can contain up to `MAX_FRAMES_PER_ASYNC_EVENT = 100` frames. Without a microtask checkpoint between callbacks, all 100 fire back-to-back. Any async work the adapter queues inside `onMessage` (e.g. a resolved Promise that dequeues the next item from a processing queue) accumulates as 100 pending microtasks instead of being interleaved one-per-frame. The processing queue overflows → "overloaded" warning → missed/malformed deliveries → "bad frame".

## Fix

Replace `fn.Call()` with `napi_make_callback()` in `async_receiver_ready()` — the code path that is called from a `uv_async_t` callback (i.e. *outside* a running JS call, exactly the case `napi_make_callback` is designed for). This restores `node::MakeCallback` semantics.

Secondary fix: replace the silent `env.IsExceptionPending() + break` pattern with `napi_get_and_clear_last_exception` + `napi_fatal_exception`, matching what `Nan::FatalException` / `Nan::TryCatch` did. Without this, a single thrown exception leaves the env in a corrupted state where all subsequent `napi_*` calls silently fail, delivering empty `{}` objects to listeners (the adapter sees them as "bad frames").

## Test

`test/test-callback_ordering.js` — sends 30 frames in one batch and verifies that the Promise / `process.nextTick` scheduled by callback N has resolved before callback N+1 fires. This test would fail deterministically against the old `fn.Call()` code.

## Checklist
- [x] Reproduces the reported regression scenario
- [x] New test added that would fail without the fix
- [x] CHANGELOG updated
- [x] CI passes (Node.js 22 + 24, Ubuntu)

🤖 Generated with [Claude Code](https://claude.com/claude-code)