### PR TITLE
Add float32 (single) and float64 (double) signal type support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,16 @@ Keep pull requests focused. One logical change per PR is easier to review and me
 
 ## Code style
 
-TypeScript source is formatted with Prettier and linted with ESLint. Run `npm run lint` to auto-fix. Native C++ code (`native/`) follows the style of the surrounding code — no tabs, 4-space indent.
+**TypeScript:** Prettier + ESLint — run `npm run lint` to auto-fix. Use `===`, named constants over magic numbers.
+
+**C++ (`native/`):** C++20 (`-std=c++20`), 4-space indent, no tabs.
+- `enum class` over `typedef enum`; `static_cast<>` over C-style casts
+- `std::bit_cast<>` for type punning; `std::memcpy` when reading typed values from a `uint8_t` buffer (never cast the pointer)
+- ISO types (`uint32_t`) not POSIX aliases (`u_int32_t`); C++ headers (`<cstdint>`) not C ones (`<stdint.h>`)
+- Throw a `Napi::TypeError` on bad input — no silent fallbacks; check `env.IsExceptionPending()` after any helper that may throw
+- `[[nodiscard]]` on functions whose return value must not be ignored
+
+**Tests:** cover both endiannesses for byte-order-sensitive code; include round-trip (encode → decode) cases; test invalid arguments to verify error paths throw.
 
 ## Reporting bugs
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,7 +6,8 @@
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include_dir\")"
       ],
-      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ]
+      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
+      "cflags_cc": [ "-std=c++20" ]
     },
     {
       "target_name": "can_signals",
@@ -14,7 +15,8 @@
       "include_dirs": [
         "<!@(node -p \"require('node-addon-api').include_dir\")"
       ],
-      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ]
+      "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
+      "cflags_cc": [ "-std=c++20" ]
     }
   ]
 }

--- a/native/signals.cc
+++ b/native/signals.cc
@@ -13,14 +13,12 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define __STDC_LIMIT_MACROS
-
 #include <napi.h>
 
 #include <algorithm>
-
-#include <stdint.h>
-#include <string.h>
+#include <bit>
+#include <cstdint>
+#include <cstring>
 
 #define CHECK_CONDITION(expr, str) \
   if (!(expr)) { \
@@ -28,77 +26,64 @@
     return env.Undefined(); \
   }
 
-typedef enum ENDIANESS
+enum class ENDIANESS
 {
-    ENDIANESS_MOTOROLA = 0,
-    ENDIANESS_INTEL
-} ENDIANESS;
+    MOTOROLA = 0,
+    INTEL
+};
 
-typedef enum SIGNAL_TYPE
+enum class SIGNAL_TYPE
 {
-    SIGNAL_TYPE_UNSIGNED = 0,
-    SIGNAL_TYPE_SIGNED   = 1,
-    SIGNAL_TYPE_FLOAT32  = 2,
-    SIGNAL_TYPE_FLOAT64  = 3
-} SIGNAL_TYPE;
+    UNSIGNED = 0,
+    SIGNED   = 1,
+    FLOAT32  = 2,
+    FLOAT64  = 3
+};
 
-static SIGNAL_TYPE _parse_signal_type(const Napi::Value& v)
+static SIGNAL_TYPE _parse_signal_type(Napi::Env env, const Napi::Value& v)
 {
     if (v.IsBoolean())
-        return v.As<Napi::Boolean>().Value() ? SIGNAL_TYPE_SIGNED : SIGNAL_TYPE_UNSIGNED;
+        return v.As<Napi::Boolean>().Value() ? SIGNAL_TYPE::SIGNED : SIGNAL_TYPE::UNSIGNED;
     uint32_t n = v.As<Napi::Number>().Uint32Value();
-    if (n > SIGNAL_TYPE_FLOAT64)
-        return SIGNAL_TYPE_UNSIGNED;   // safe fallback for unknown values
-    return (SIGNAL_TYPE)n;
+    if (n > static_cast<uint32_t>(SIGNAL_TYPE::FLOAT64)) {
+        Napi::TypeError::New(env, "Unknown signal type").ThrowAsJavaScriptException();
+        return SIGNAL_TYPE::UNSIGNED;
+    }
+    return static_cast<SIGNAL_TYPE>(n);
 }
 
 // Returns the fixed IEEE-754 bit width for float signal types; 0 for integer types.
 static uint32_t signal_type_bit_width(SIGNAL_TYPE t)
 {
     switch (t) {
-        case SIGNAL_TYPE_FLOAT32: return 32;
-        case SIGNAL_TYPE_FLOAT64: return 64;
-        default:                  return 0;
+        case SIGNAL_TYPE::FLOAT32: return 32;
+        case SIGNAL_TYPE::FLOAT64: return 64;
+        default:                   return 0;
     }
 }
 
 //-----------------------------------------------------------------------------------------
 // _signals.* methods
 
-static u_int64_t _getvalue(u_int8_t * data,
-                           u_int32_t offset,
-                           u_int32_t length,
-                           ENDIANESS byteOrder)
+[[nodiscard]] static uint64_t _getvalue(const uint8_t* data,
+                                        uint32_t offset,
+                                        uint32_t length,
+                                        ENDIANESS byteOrder)
 {
-    uint64_t d;
-    uint64_t o = 0;
+    uint64_t d_raw;
+    std::memcpy(&d_raw, data, sizeof(d_raw));
+    uint64_t d = (byteOrder == ENDIANESS::INTEL) ? le64toh(d_raw) : be64toh(d_raw);
 
-    if (byteOrder == ENDIANESS_INTEL) {
-        d = le64toh(*((uint64_t *)&data[0]));
-    } else {
-        d = be64toh(*((uint64_t *)&data[0]));
-    }
+    uint64_t m = (length == 64) ? UINT64_MAX : (UINT64_C(1) << length) - 1;
+    size_t shift = (byteOrder == ENDIANESS::INTEL) ? offset : (64 - offset - length);
 
-    uint64_t m;
-    if (length == 64) {
-      m = (uint64_t) UINT64_MAX;
-    } else {
-      m = (1LLU << length) - 1;
-    }
-    size_t shift;
-    if (byteOrder == ENDIANESS_INTEL) {
-        shift = offset;
-    } else {
-        shift = 64 - offset - length;
-    }
-
-    o = (d >> shift) & m;
+    uint64_t o = (d >> shift) & m;
 
 #ifdef KAYAK_DATA_CHECK
     size_t i;
     int bitNr;
     uint64_t val = 0;
-    if (byteOrder == ENDIANESS_INTEL) {
+    if (byteOrder == ENDIANESS::INTEL) {
         for (i = 0; i < length; i++) {
             bitNr = i + offset;
             val |= ((data[bitNr >> 3] >> (bitNr & 0x07)) & 1) << i;
@@ -142,8 +127,9 @@ Napi::Value DecodeSignal(const Napi::CallbackInfo& info)
 
     offset     = info[1].As<Napi::Number>().Uint32Value();
     bitLength  = info[2].As<Napi::Number>().Uint32Value();
-    endianess  = info[3].As<Napi::Boolean>().Value() ? ENDIANESS_INTEL : ENDIANESS_MOTOROLA;
-    SIGNAL_TYPE signalType = _parse_signal_type(info[4]);
+    endianess  = info[3].As<Napi::Boolean>().Value() ? ENDIANESS::INTEL : ENDIANESS::MOTOROLA;
+    SIGNAL_TYPE signalType = _parse_signal_type(env, info[4]);
+    if (env.IsExceptionPending()) return env.Undefined();
 
     // Float types have a fixed width dictated by the type, not the caller.
     // Using signal_type_bit_width() ensures encode and decode always agree.
@@ -152,78 +138,60 @@ Napi::Value DecodeSignal(const Napi::CallbackInfo& info)
 
     size_t maxBytes = std::min<size_t>(jsData.ByteLength(), sizeof(data));
 
-    memset(data, 0, sizeof(data));
-    memcpy(data, jsData.Data(), maxBytes);
+    std::memset(data, 0, sizeof(data));
+    std::memcpy(data, jsData.Data(), maxBytes);
 
     uint64_t val = _getvalue(data, offset, effectiveBitLength, endianess);
 
     Napi::Value retval;
-    if (signalType == SIGNAL_TYPE_FLOAT32) {
+    if (signalType == SIGNAL_TYPE::FLOAT32) {
         // Reinterpret the 32 raw bits as IEEE-754 single precision.
-        // _getvalue already applied the correct byte order, so a plain
-        // memcpy into a float gives the right value on any host endianness.
-        uint32_t raw = (uint32_t)val;
-        float f;
-        memcpy(&f, &raw, sizeof(f));
-        retval = Napi::Number::New(env, (double)f);
-    } else if (signalType == SIGNAL_TYPE_FLOAT64) {
-        double d;
-        memcpy(&d, &val, sizeof(d));
-        retval = Napi::Number::New(env, d);
-    } else if (signalType == SIGNAL_TYPE_SIGNED && val & (1LLU << (bitLength - 1))) {
-        int32_t tmp = -1 * (~((UINT64_MAX << bitLength) | val) + 1);
-        retval = Napi::Number::New(env, tmp);
+        // _getvalue already applied the correct byte order, so std::bit_cast
+        // gives the right value on any host endianness.
+        retval = Napi::Number::New(env,
+            static_cast<double>(std::bit_cast<float>(static_cast<uint32_t>(val))));
+    } else if (signalType == SIGNAL_TYPE::FLOAT64) {
+        retval = Napi::Number::New(env, std::bit_cast<double>(val));
+    } else if (signalType == SIGNAL_TYPE::SIGNED && (val & (UINT64_C(1) << (bitLength - 1)))) {
+        // Sign-extend from bitLength bits to int64_t.
+        // XOR-subtract avoids UB that a naive left-shift approach would have.
+        uint64_t sign_mask = UINT64_C(1) << (bitLength - 1);
+        int64_t tmp = static_cast<int64_t>((val ^ sign_mask) - sign_mask);
+        retval = Napi::Number::New(env, static_cast<double>(tmp));
     } else {
-        retval = Napi::Number::New(env, (uint32_t)val);
+        retval = Napi::Number::New(env, static_cast<uint32_t>(val));
     }
 
     Napi::Array raw_values = Napi::Array::New(env, 2);
     raw_values.Set(0u, retval);
     // For float types the full value is in index 0; index 1 is always 0.
-    uint32_t hi = (width > 0) ? 0u : (uint32_t)(val >> 32);
+    uint32_t hi = (width > 0) ? 0u : static_cast<uint32_t>(val >> 32);
     raw_values.Set(1u, Napi::Number::New(env, hi));
 
     return raw_values;
 }
 
-void _setvalue(u_int32_t offset, u_int32_t bitLength, ENDIANESS endianess, u_int8_t data[8], u_int64_t raw_value)
+static void _setvalue(uint32_t offset, uint32_t bitLength, ENDIANESS endianess,
+                      uint8_t* data, uint64_t raw_value)
 {
-    uint64_t o;
-    if (endianess == ENDIANESS_INTEL) {
-        o = le64toh(*((uint64_t *)&data[0]));
-    } else {
-        o = be64toh(*((uint64_t *)&data[0]));
-    }
+    uint64_t o_raw;
+    std::memcpy(&o_raw, data, sizeof(o_raw));
+    uint64_t o = (endianess == ENDIANESS::INTEL) ? le64toh(o_raw) : be64toh(o_raw);
 
-    uint64_t m = 0;
-    if (bitLength == 64) {
-      m = (uint64_t) UINT64_MAX;
-    } else {
-      m = (1LLU << bitLength) - 1;
-    }
-    size_t shift;
-    if (endianess == ENDIANESS_INTEL) {
-        shift = offset;
-    } else {
-        shift = 64 - offset - bitLength;
-    }
+    uint64_t m = (bitLength == 64) ? UINT64_MAX : (UINT64_C(1) << bitLength) - 1;
+    size_t shift = (endianess == ENDIANESS::INTEL) ? offset : (64 - offset - bitLength);
 
-    o &= (uint64_t) ~(m << shift);
-    o |= (uint64_t) (raw_value & m) << shift;
+    o &= ~(m << shift);
+    o |= (raw_value & m) << shift;
 
-    if (endianess == ENDIANESS_INTEL) {
-        o = htole64(o);
-    } else {
-        o = htobe64(o);
-    }
-
-    memcpy(&data[0], &o, 8);
+    o = (endianess == ENDIANESS::INTEL) ? htole64(o) : htobe64(o);
+    std::memcpy(data, &o, sizeof(o));
 
 #ifdef KAYAK_DATA_CHECK
     size_t i;
     int bitNr;
     uint64_t val = 0;
-    if (endianess == ENDIANESS_INTEL) {
+    if (endianess == ENDIANESS::INTEL) {
         for (i = 0; i < bitLength; i++) {
             bitNr = i + offset;
             val |= ((data[bitNr >> 3] >> (bitNr & 0x07)) & 1) << i;
@@ -267,31 +235,30 @@ Napi::Value EncodeSignal(const Napi::CallbackInfo& info)
 
     offset     = info[1].As<Napi::Number>().Uint32Value();
     bitLength  = info[2].As<Napi::Number>().Uint32Value();
-    endianess  = info[3].As<Napi::Boolean>().Value() ? ENDIANESS_INTEL : ENDIANESS_MOTOROLA;
-    SIGNAL_TYPE signalType = _parse_signal_type(info[4]);
+    endianess  = info[3].As<Napi::Boolean>().Value() ? ENDIANESS::INTEL : ENDIANESS::MOTOROLA;
+    SIGNAL_TYPE signalType = _parse_signal_type(env, info[4]);
+    if (env.IsExceptionPending()) return env.Undefined();
 
     size_t maxBytes = std::min<size_t>(jsData.ByteLength(), sizeof(data));
-    memcpy(data, jsData.Data(), maxBytes);
+    std::memcpy(data, jsData.Data(), maxBytes);
 
-    if (signalType == SIGNAL_TYPE_FLOAT32) {
-        float f = (float)info[5].As<Napi::Number>().DoubleValue();
-        uint32_t raw;
-        memcpy(&raw, &f, sizeof(raw));
-        _setvalue(offset, signal_type_bit_width(SIGNAL_TYPE_FLOAT32), endianess, data, (uint64_t)raw);
-    } else if (signalType == SIGNAL_TYPE_FLOAT64) {
+    if (signalType == SIGNAL_TYPE::FLOAT32) {
+        float f = static_cast<float>(info[5].As<Napi::Number>().DoubleValue());
+        _setvalue(offset, signal_type_bit_width(SIGNAL_TYPE::FLOAT32), endianess, data,
+                  static_cast<uint64_t>(std::bit_cast<uint32_t>(f)));
+    } else if (signalType == SIGNAL_TYPE::FLOAT64) {
         double d = info[5].As<Napi::Number>().DoubleValue();
-        uint64_t raw;
-        memcpy(&raw, &d, sizeof(raw));
-        _setvalue(offset, signal_type_bit_width(SIGNAL_TYPE_FLOAT64), endianess, data, raw);
+        _setvalue(offset, signal_type_bit_width(SIGNAL_TYPE::FLOAT64), endianess, data,
+                  std::bit_cast<uint64_t>(d));
     } else {
-        uint64_t raw_value = info[5].As<Napi::Number>().Uint32Value();
+        uint64_t raw_value = static_cast<uint64_t>(info[5].As<Napi::Number>().Uint32Value());
         if (info.Length() > 6 && (info[6].IsNumber() || info[6].IsBoolean())) {
-            raw_value += ((uint64_t)info[6].As<Napi::Number>().Uint32Value()) << 32;
+            raw_value += static_cast<uint64_t>(info[6].As<Napi::Number>().Uint32Value()) << 32;
         }
         _setvalue(offset, bitLength, endianess, data, raw_value);
     }
 
-    memcpy(jsData.Data(), data, maxBytes);
+    std::memcpy(jsData.Data(), data, maxBytes);
 
     return env.Undefined();
 }

--- a/native/signals.cc
+++ b/native/signals.cc
@@ -46,10 +46,20 @@ static SIGNAL_TYPE _parse_signal_type(const Napi::Value& v)
 {
     if (v.IsBoolean())
         return v.As<Napi::Boolean>().Value() ? SIGNAL_TYPE_SIGNED : SIGNAL_TYPE_UNSIGNED;
-    u_int32_t n = v.As<Napi::Number>().Uint32Value();
+    uint32_t n = v.As<Napi::Number>().Uint32Value();
     if (n > SIGNAL_TYPE_FLOAT64)
         return SIGNAL_TYPE_UNSIGNED;   // safe fallback for unknown values
     return (SIGNAL_TYPE)n;
+}
+
+// Returns the fixed IEEE-754 bit width for float signal types; 0 for integer types.
+static uint32_t signal_type_bit_width(SIGNAL_TYPE t)
+{
+    switch (t) {
+        case SIGNAL_TYPE_FLOAT32: return 32;
+        case SIGNAL_TYPE_FLOAT64: return 64;
+        default:                  return 0;
+    }
 }
 
 //-----------------------------------------------------------------------------------------
@@ -117,9 +127,9 @@ static u_int64_t _getvalue(u_int8_t * data,
 Napi::Value DecodeSignal(const Napi::CallbackInfo& info)
 {
     Napi::Env env = info.Env();
-    u_int32_t offset, bitLength;
+    uint32_t offset, bitLength;
     ENDIANESS endianess;
-    u_int8_t data[64];           // CANFD buffer size (supports CAN FD)
+    uint8_t data[64];           // CANFD buffer size (supports CAN FD)
 
     CHECK_CONDITION(info.Length() == 5, "Too few arguments");
     CHECK_CONDITION(info[0].IsBuffer(), "Invalid argument");
@@ -135,11 +145,10 @@ Napi::Value DecodeSignal(const Napi::CallbackInfo& info)
     endianess  = info[3].As<Napi::Boolean>().Value() ? ENDIANESS_INTEL : ENDIANESS_MOTOROLA;
     SIGNAL_TYPE signalType = _parse_signal_type(info[4]);
 
-    // Float types have a fixed width; use that instead of the caller-supplied
-    // bitLength so a mismatch can never produce a silently wrong result.
-    u_int32_t effectiveBitLength = (signalType == SIGNAL_TYPE_FLOAT32) ? 32u
-                                 : (signalType == SIGNAL_TYPE_FLOAT64) ? 64u
-                                 : bitLength;
+    // Float types have a fixed width dictated by the type, not the caller.
+    // Using signal_type_bit_width() ensures encode and decode always agree.
+    uint32_t width = signal_type_bit_width(signalType);
+    uint32_t effectiveBitLength = (width > 0) ? width : bitLength;
 
     size_t maxBytes = std::min<size_t>(jsData.ByteLength(), sizeof(data));
 
@@ -153,7 +162,7 @@ Napi::Value DecodeSignal(const Napi::CallbackInfo& info)
         // Reinterpret the 32 raw bits as IEEE-754 single precision.
         // _getvalue already applied the correct byte order, so a plain
         // memcpy into a float gives the right value on any host endianness.
-        u_int32_t raw = (u_int32_t)val;
+        uint32_t raw = (uint32_t)val;
         float f;
         memcpy(&f, &raw, sizeof(f));
         retval = Napi::Number::New(env, (double)f);
@@ -165,14 +174,13 @@ Napi::Value DecodeSignal(const Napi::CallbackInfo& info)
         int32_t tmp = -1 * (~((UINT64_MAX << bitLength) | val) + 1);
         retval = Napi::Number::New(env, tmp);
     } else {
-        retval = Napi::Number::New(env, (u_int32_t)val);
+        retval = Napi::Number::New(env, (uint32_t)val);
     }
 
     Napi::Array raw_values = Napi::Array::New(env, 2);
     raw_values.Set(0u, retval);
-    // For float types the value fits in index 0; index 1 is always 0.
-    u_int32_t hi = (signalType == SIGNAL_TYPE_FLOAT32 || signalType == SIGNAL_TYPE_FLOAT64)
-                   ? 0u : (u_int32_t)(val >> 32);
+    // For float types the full value is in index 0; index 1 is always 0.
+    uint32_t hi = (width > 0) ? 0u : (uint32_t)(val >> 32);
     raw_values.Set(1u, Napi::Number::New(env, hi));
 
     return raw_values;
@@ -243,9 +251,9 @@ void _setvalue(u_int32_t offset, u_int32_t bitLength, ENDIANESS endianess, u_int
 Napi::Value EncodeSignal(const Napi::CallbackInfo& info)
 {
     Napi::Env env = info.Env();
-    u_int32_t offset, bitLength;
+    uint32_t offset, bitLength;
     ENDIANESS endianess;
-    u_int8_t data[64];           // CANFD buffer size (supports CAN FD)
+    uint8_t data[64];           // CANFD buffer size (supports CAN FD)
 
     CHECK_CONDITION(info.Length() >= 6, "Too few arguments");
     CHECK_CONDITION(info[0].IsBuffer(), "Invalid argument");
@@ -267,18 +275,18 @@ Napi::Value EncodeSignal(const Napi::CallbackInfo& info)
 
     if (signalType == SIGNAL_TYPE_FLOAT32) {
         float f = (float)info[5].As<Napi::Number>().DoubleValue();
-        u_int32_t raw;
+        uint32_t raw;
         memcpy(&raw, &f, sizeof(raw));
-        _setvalue(offset, 32, endianess, data, (u_int64_t)raw);
+        _setvalue(offset, signal_type_bit_width(SIGNAL_TYPE_FLOAT32), endianess, data, (uint64_t)raw);
     } else if (signalType == SIGNAL_TYPE_FLOAT64) {
         double d = info[5].As<Napi::Number>().DoubleValue();
-        u_int64_t raw;
+        uint64_t raw;
         memcpy(&raw, &d, sizeof(raw));
-        _setvalue(offset, 64, endianess, data, raw);
+        _setvalue(offset, signal_type_bit_width(SIGNAL_TYPE_FLOAT64), endianess, data, raw);
     } else {
-        u_int64_t raw_value = info[5].As<Napi::Number>().Uint32Value();
+        uint64_t raw_value = info[5].As<Napi::Number>().Uint32Value();
         if (info.Length() > 6 && (info[6].IsNumber() || info[6].IsBoolean())) {
-            raw_value += ((u_int64_t)info[6].As<Napi::Number>().Uint32Value()) << 32;
+            raw_value += ((uint64_t)info[6].As<Napi::Number>().Uint32Value()) << 32;
         }
         _setvalue(offset, bitLength, endianess, data, raw_value);
     }

--- a/native/signals.cc
+++ b/native/signals.cc
@@ -46,7 +46,10 @@ static SIGNAL_TYPE _parse_signal_type(const Napi::Value& v)
 {
     if (v.IsBoolean())
         return v.As<Napi::Boolean>().Value() ? SIGNAL_TYPE_SIGNED : SIGNAL_TYPE_UNSIGNED;
-    return (SIGNAL_TYPE)v.As<Napi::Number>().Uint32Value();
+    u_int32_t n = v.As<Napi::Number>().Uint32Value();
+    if (n > SIGNAL_TYPE_FLOAT64)
+        return SIGNAL_TYPE_UNSIGNED;   // safe fallback for unknown values
+    return (SIGNAL_TYPE)n;
 }
 
 //-----------------------------------------------------------------------------------------
@@ -116,7 +119,7 @@ Napi::Value DecodeSignal(const Napi::CallbackInfo& info)
     Napi::Env env = info.Env();
     u_int32_t offset, bitLength;
     ENDIANESS endianess;
-    u_int8_t data[64];           // CANFD size of bufer = 64
+    u_int8_t data[64];           // CANFD buffer size (supports CAN FD)
 
     CHECK_CONDITION(info.Length() == 5, "Too few arguments");
     CHECK_CONDITION(info[0].IsBuffer(), "Invalid argument");
@@ -132,18 +135,24 @@ Napi::Value DecodeSignal(const Napi::CallbackInfo& info)
     endianess  = info[3].As<Napi::Boolean>().Value() ? ENDIANESS_INTEL : ENDIANESS_MOTOROLA;
     SIGNAL_TYPE signalType = _parse_signal_type(info[4]);
 
+    // Float types have a fixed width; use that instead of the caller-supplied
+    // bitLength so a mismatch can never produce a silently wrong result.
+    u_int32_t effectiveBitLength = (signalType == SIGNAL_TYPE_FLOAT32) ? 32u
+                                 : (signalType == SIGNAL_TYPE_FLOAT64) ? 64u
+                                 : bitLength;
+
     size_t maxBytes = std::min<size_t>(jsData.ByteLength(), sizeof(data));
 
     memset(data, 0, sizeof(data));
     memcpy(data, jsData.Data(), maxBytes);
 
-    uint64_t val = _getvalue(data, offset, bitLength, endianess);
+    uint64_t val = _getvalue(data, offset, effectiveBitLength, endianess);
 
     Napi::Value retval;
     if (signalType == SIGNAL_TYPE_FLOAT32) {
         // Reinterpret the 32 raw bits as IEEE-754 single precision.
         // _getvalue already applied the correct byte order, so a plain
-        // memcpy into a float gives the right value on any host endianess.
+        // memcpy into a float gives the right value on any host endianness.
         u_int32_t raw = (u_int32_t)val;
         float f;
         memcpy(&f, &raw, sizeof(f));
@@ -236,7 +245,7 @@ Napi::Value EncodeSignal(const Napi::CallbackInfo& info)
     Napi::Env env = info.Env();
     u_int32_t offset, bitLength;
     ENDIANESS endianess;
-    u_int8_t data[64];           // CANFD size of bufer = 64
+    u_int8_t data[64];           // CANFD buffer size (supports CAN FD)
 
     CHECK_CONDITION(info.Length() >= 6, "Too few arguments");
     CHECK_CONDITION(info[0].IsBuffer(), "Invalid argument");

--- a/native/signals.cc
+++ b/native/signals.cc
@@ -34,6 +34,21 @@ typedef enum ENDIANESS
     ENDIANESS_INTEL
 } ENDIANESS;
 
+typedef enum SIGNAL_TYPE
+{
+    SIGNAL_TYPE_UNSIGNED = 0,
+    SIGNAL_TYPE_SIGNED   = 1,
+    SIGNAL_TYPE_FLOAT32  = 2,
+    SIGNAL_TYPE_FLOAT64  = 3
+} SIGNAL_TYPE;
+
+static SIGNAL_TYPE _parse_signal_type(const Napi::Value& v)
+{
+    if (v.IsBoolean())
+        return v.As<Napi::Boolean>().Value() ? SIGNAL_TYPE_SIGNED : SIGNAL_TYPE_UNSIGNED;
+    return (SIGNAL_TYPE)v.As<Napi::Number>().Uint32Value();
+}
+
 //-----------------------------------------------------------------------------------------
 // _signals.* methods
 
@@ -94,14 +109,13 @@ static u_int64_t _getvalue(u_int8_t * data,
 // arg[0] - Data array
 // arg[1] - offset zero indexed
 // arg[2] - bitLength one indexed
-// arg[3] - endianess
-// arg[4] - signed flag
+// arg[3] - endianess (bool: true=Intel/LE, false=Motorola/BE)
+// arg[4] - signal type: bool (false=unsigned, true=signed) or number (0=unsigned, 1=signed, 2=float32, 3=float64)
 Napi::Value DecodeSignal(const Napi::CallbackInfo& info)
 {
     Napi::Env env = info.Env();
     u_int32_t offset, bitLength;
     ENDIANESS endianess;
-    bool isSigned = false;
     u_int8_t data[64];           // CANFD size of bufer = 64
 
     CHECK_CONDITION(info.Length() == 5, "Too few arguments");
@@ -109,14 +123,14 @@ Napi::Value DecodeSignal(const Napi::CallbackInfo& info)
     CHECK_CONDITION(info[1].IsNumber(), "Invalid offset");
     CHECK_CONDITION(info[2].IsNumber(), "Invalid bit length");
     CHECK_CONDITION(info[3].IsBoolean(), "Invalid endianess");
-    CHECK_CONDITION(info[4].IsBoolean(), "Invalid signed flag");
+    CHECK_CONDITION(info[4].IsNumber() || info[4].IsBoolean(), "Invalid type");
 
     Napi::Buffer<uint8_t> jsData = info[0].As<Napi::Buffer<uint8_t>>();
 
-    offset    = info[1].As<Napi::Number>().Uint32Value();
-    bitLength = info[2].As<Napi::Number>().Uint32Value();
-    endianess = info[3].As<Napi::Boolean>().Value() ? ENDIANESS_INTEL : ENDIANESS_MOTOROLA;
-    isSigned  = info[4].As<Napi::Boolean>().Value();
+    offset     = info[1].As<Napi::Number>().Uint32Value();
+    bitLength  = info[2].As<Napi::Number>().Uint32Value();
+    endianess  = info[3].As<Napi::Boolean>().Value() ? ENDIANESS_INTEL : ENDIANESS_MOTOROLA;
+    SIGNAL_TYPE signalType = _parse_signal_type(info[4]);
 
     size_t maxBytes = std::min<size_t>(jsData.ByteLength(), sizeof(data));
 
@@ -126,7 +140,19 @@ Napi::Value DecodeSignal(const Napi::CallbackInfo& info)
     uint64_t val = _getvalue(data, offset, bitLength, endianess);
 
     Napi::Value retval;
-    if (isSigned && val & (1LLU << (bitLength - 1))) {
+    if (signalType == SIGNAL_TYPE_FLOAT32) {
+        // Reinterpret the 32 raw bits as IEEE-754 single precision.
+        // _getvalue already applied the correct byte order, so a plain
+        // memcpy into a float gives the right value on any host endianess.
+        u_int32_t raw = (u_int32_t)val;
+        float f;
+        memcpy(&f, &raw, sizeof(f));
+        retval = Napi::Number::New(env, (double)f);
+    } else if (signalType == SIGNAL_TYPE_FLOAT64) {
+        double d;
+        memcpy(&d, &val, sizeof(d));
+        retval = Napi::Number::New(env, d);
+    } else if (signalType == SIGNAL_TYPE_SIGNED && val & (1LLU << (bitLength - 1))) {
         int32_t tmp = -1 * (~((UINT64_MAX << bitLength) | val) + 1);
         retval = Napi::Number::New(env, tmp);
     } else {
@@ -135,7 +161,10 @@ Napi::Value DecodeSignal(const Napi::CallbackInfo& info)
 
     Napi::Array raw_values = Napi::Array::New(env, 2);
     raw_values.Set(0u, retval);
-    raw_values.Set(1u, Napi::Number::New(env, (u_int32_t)(val >> 32)));
+    // For float types the value fits in index 0; index 1 is always 0.
+    u_int32_t hi = (signalType == SIGNAL_TYPE_FLOAT32 || signalType == SIGNAL_TYPE_FLOAT64)
+                   ? 0u : (u_int32_t)(val >> 32);
+    raw_values.Set(1u, Napi::Number::New(env, hi));
 
     return raw_values;
 }
@@ -198,42 +227,52 @@ void _setvalue(u_int32_t offset, u_int32_t bitLength, ENDIANESS endianess, u_int
 // arg[0] - Data array
 // arg[1] - bitOffset
 // arg[2] - bitLength
-// arg[3] - endianess
-// arg[4] - sign flag
-// arg[5] - first 4 bytes value to encode
-// arg[6] - second 4 bytes value to encode
+// arg[3] - endianess (bool: true=Intel/LE, false=Motorola/BE)
+// arg[4] - signal type: bool (false=unsigned, true=signed) or number (0=unsigned, 1=signed, 2=float32, 3=float64)
+// arg[5] - value to encode (integer lo-word for int types; float/double JS number for float types)
+// arg[6] - (integer types only) high 32 bits for 64-bit integers
 Napi::Value EncodeSignal(const Napi::CallbackInfo& info)
 {
     Napi::Env env = info.Env();
     u_int32_t offset, bitLength;
     ENDIANESS endianess;
     u_int8_t data[64];           // CANFD size of bufer = 64
-    u_int64_t raw_value;
 
     CHECK_CONDITION(info.Length() >= 6, "Too few arguments");
     CHECK_CONDITION(info[0].IsBuffer(), "Invalid argument");
     CHECK_CONDITION(info[1].IsNumber(), "Invalid offset");
     CHECK_CONDITION(info[2].IsNumber(), "Invalid bit length");
     CHECK_CONDITION(info[3].IsBoolean(), "Invalid endianess");
-    CHECK_CONDITION(info[4].IsBoolean(), "Invalid sign flag");
+    CHECK_CONDITION(info[4].IsNumber() || info[4].IsBoolean(), "Invalid type");
     CHECK_CONDITION(info[5].IsNumber() || info[5].IsBoolean(), "Invalid value");
 
     Napi::Buffer<uint8_t> jsData = info[0].As<Napi::Buffer<uint8_t>>();
 
-    offset    = info[1].As<Napi::Number>().Uint32Value();
-    bitLength = info[2].As<Napi::Number>().Uint32Value();
-    endianess = info[3].As<Napi::Boolean>().Value() ? ENDIANESS_INTEL : ENDIANESS_MOTOROLA;
-
-    raw_value = info[5].As<Napi::Number>().Uint32Value();
-    if (info.Length() > 6 && (info[6].IsNumber() || info[6].IsBoolean())) {
-        raw_value += ((u_int64_t)info[6].As<Napi::Number>().Uint32Value()) << 32;
-    }
+    offset     = info[1].As<Napi::Number>().Uint32Value();
+    bitLength  = info[2].As<Napi::Number>().Uint32Value();
+    endianess  = info[3].As<Napi::Boolean>().Value() ? ENDIANESS_INTEL : ENDIANESS_MOTOROLA;
+    SIGNAL_TYPE signalType = _parse_signal_type(info[4]);
 
     size_t maxBytes = std::min<size_t>(jsData.ByteLength(), sizeof(data));
-
     memcpy(data, jsData.Data(), maxBytes);
 
-    _setvalue(offset, bitLength, endianess, data, raw_value);
+    if (signalType == SIGNAL_TYPE_FLOAT32) {
+        float f = (float)info[5].As<Napi::Number>().DoubleValue();
+        u_int32_t raw;
+        memcpy(&raw, &f, sizeof(raw));
+        _setvalue(offset, 32, endianess, data, (u_int64_t)raw);
+    } else if (signalType == SIGNAL_TYPE_FLOAT64) {
+        double d = info[5].As<Napi::Number>().DoubleValue();
+        u_int64_t raw;
+        memcpy(&raw, &d, sizeof(raw));
+        _setvalue(offset, 64, endianess, data, raw);
+    } else {
+        u_int64_t raw_value = info[5].As<Napi::Number>().Uint32Value();
+        if (info.Length() > 6 && (info[6].IsNumber() || info[6].IsBoolean())) {
+            raw_value += ((u_int64_t)info[6].As<Napi::Number>().Uint32Value()) << 32;
+        }
+        _setvalue(offset, bitLength, endianess, data, raw_value);
+    }
 
     memcpy(jsData.Data(), data, maxBytes);
 

--- a/src/can_signals.d.ts
+++ b/src/can_signals.d.ts
@@ -1,32 +1,38 @@
 declare module "*can_signals.node" {
+	// Signal type constants passed as the 5th argument.
+	// Accepts a boolean for backward compatibility (false=unsigned, true=signed).
+	// 0 = unsigned, 1 = signed, 2 = float32 (single), 3 = float64 (double)
+	type SignalType = boolean | number;
+
 	// Decode signal according description
 	// arg[0] - Data array
 	// arg[1] - offset zero indexed
 	// arg[2] - bitLength one indexed
-	// arg[3] - endianess
-	// arg[4] - signed flag
+	// arg[3] - endianess (true = Intel/LE, false = Motorola/BE)
+	// arg[4] - signal type
+	// Returns [value, hi32] where hi32 is 0 for float/double types.
 	export function decodeSignal(
 		data: Buffer,
 		bitOffset: number,
 		bitLength: number,
 		endianess: boolean,
-		signed: boolean
+		signalType: SignalType
 	): number[];
 
 	// Encode signal according description
 	// arg[0] - Data array
 	// arg[1] - bitOffset
 	// arg[2] - bitLength
-	// arg[3] - endianess
-	// arg[4] - signed flag
-	// arg[5] - first 4 bytes value to encode
-	// arg[6] - second 4 bytes value to encode
+	// arg[3] - endianess (true = Intel/LE, false = Motorola/BE)
+	// arg[4] - signal type
+	// arg[5] - value: low 32-bit word for integer types; full float/double for float types
+	// arg[6] - (integer types only) high 32-bit word for 64-bit integers
 	export function encodeSignal(
 		data: Buffer,
 		bitOffset: number,
 		bitLength: number,
 		endianess: boolean,
-		signed: boolean,
+		signalType: SignalType,
 		word1: number | boolean,
 		word2?: number | boolean
 	): void;

--- a/src/can_signals.d.ts
+++ b/src/can_signals.d.ts
@@ -2,7 +2,7 @@ declare module "*can_signals.node" {
 	// Signal type constants passed as the 5th argument.
 	// Accepts a boolean for backward compatibility (false=unsigned, true=signed).
 	// 0 = unsigned, 1 = signed, 2 = float32 (single), 3 = float64 (double)
-	type SignalType = boolean | number;
+	type SignalType = boolean | 0 | 1 | 2 | 3;
 
 	// Decode signal according description
 	// arg[0] - Data array

--- a/src/can_signals.d.ts
+++ b/src/can_signals.d.ts
@@ -1,7 +1,7 @@
 declare module "*can_signals.node" {
-	// Signal type constants passed as the 5th argument.
+	// Numeric signal type passed as the 5th argument to encode/decode.
+	// Use the SignalType constants exported from socketcan.ts rather than raw numbers.
 	// Accepts a boolean for backward compatibility (false=unsigned, true=signed).
-	// 0 = unsigned, 1 = signed, 2 = float32 (single), 3 = float64 (double)
 	type SignalType = boolean | 0 | 1 | 2 | 3;
 
 	// Decode signal according description

--- a/src/parse_kcd.ts
+++ b/src/parse_kcd.ts
@@ -84,7 +84,7 @@ export class Signal {
 		public slope: number = 1.0,
 		public intercept: number = 0.0,
 		public unit: string = "",
-		public type: "signed" | "unsigned" = "unsigned",
+		public type: "signed" | "unsigned" | "single" | "double" = "unsigned",
 		public defaultValue: number = 0.0,
 		public minValue?: number,
 		public maxValue?: number

--- a/src/parse_kcd.ts
+++ b/src/parse_kcd.ts
@@ -72,6 +72,8 @@ export class Node {
 	) {}
 }
 
+export type SignalType = "unsigned" | "signed" | "single" | "double";
+
 export class Signal {
 	constructor(
 		public name: string,
@@ -84,7 +86,7 @@ export class Signal {
 		public slope: number = 1.0,
 		public intercept: number = 0.0,
 		public unit: string = "",
-		public type: "signed" | "unsigned" | "single" | "double" = "unsigned",
+		public type: SignalType = "unsigned",
 		public defaultValue: number = 0.0,
 		public minValue?: number,
 		public maxValue?: number

--- a/src/socketcan.ts
+++ b/src/socketcan.ts
@@ -40,15 +40,35 @@ import * as _signals from "../build/Release/can_signals.node";
 
 import * as kcd from "./parse_kcd";
 
-// Maps KCD type string to the numeric SIGNAL_TYPE expected by the native addon.
-// 0=unsigned, 1=signed, 2=float32 (single), 3=float64 (double)
-function signalTypeCode(type: string): 0 | 1 | 2 | 3 {
-	if (type === "signed") return 1;
-	if (type === "single") return 2;
-	if (type === "double") return 3;
-	if (type !== "unsigned") console.warn(`socketcan: unknown signal type "${type}", treating as unsigned`);
-	return 0;
+/**
+ * Numeric signal-type codes understood by the can_signals native addon.
+ * Mirrors the SIGNAL_TYPE enum in native/signals.cc.
+ */
+export const SignalType = {
+	UNSIGNED: 0,
+	SIGNED:   1,
+	FLOAT32:  2,
+	FLOAT64:  3,
+} as const;
+type NativeSignalType = typeof SignalType[keyof typeof SignalType];
+
+/** Maps the KCD string type to the native numeric code. */
+function signalTypeCode(type: kcd.SignalType): NativeSignalType {
+	switch (type) {
+		case "unsigned": return SignalType.UNSIGNED;
+		case "signed":   return SignalType.SIGNED;
+		case "single":   return SignalType.FLOAT32;
+		case "double":   return SignalType.FLOAT64;
+	}
 }
+
+/** Returns true for IEEE-754 float/double signal types. */
+function isFloatSignal(type: kcd.SignalType): boolean {
+	return type === "single" || type === "double";
+}
+
+const UINT32_MAX = 0xffffffff;
+const TWO_TO_32  = 2 ** 32;
 
 /**
  * @method createRawChannel
@@ -396,7 +416,7 @@ export class DatabaseService {
 				msg.data,
 				s.bitOffset,
 				s.bitLength,
-				s.endianess == "little",
+				s.endianess === "little",
 				signalTypeCode(s.type)
 			);
 
@@ -471,31 +491,27 @@ export class DatabaseService {
 
 			const typeCode = signalTypeCode(s.type);
 
-			if (s.type === "single" || s.type === "double") {
+			if (isFloatSignal(s.type)) {
 				// Pass the floating-point value directly; the native addon handles
 				// the IEEE-754 bit reinterpretation and byte-order placement.
 				_signals.encodeSignal(
 					canmsg.data,
 					s.bitOffset,
 					s.bitLength,
-					s.endianess == "little",
+					s.endianess === "little",
 					typeCode,
 					val
 				);
 			} else {
 				// Integer path: round and split into two 32-bit words.
 				val = Math.round(val);
-				const word1 = val & 0xffffffff;
-				let word2 = 0;
-				// Bit-shift doesn't work above 32 bits; use division if needed.
-				if (val > 0xffffffff) {
-					word2 = val / Math.pow(2, 32);
-				}
+				const word1 = val & UINT32_MAX;
+				const word2 = val > UINT32_MAX ? val / TWO_TO_32 : 0;
 				_signals.encodeSignal(
 					canmsg.data,
 					s.bitOffset,
 					s.bitLength,
-					s.endianess == "little",
+					s.endianess === "little",
 					typeCode,
 					word1,
 					word2

--- a/src/socketcan.ts
+++ b/src/socketcan.ts
@@ -42,10 +42,11 @@ import * as kcd from "./parse_kcd";
 
 // Maps KCD type string to the numeric SIGNAL_TYPE expected by the native addon.
 // 0=unsigned, 1=signed, 2=float32 (single), 3=float64 (double)
-function signalTypeCode(type: string): number {
+function signalTypeCode(type: string): 0 | 1 | 2 | 3 {
 	if (type === "signed") return 1;
 	if (type === "single") return 2;
 	if (type === "double") return 3;
+	if (type !== "unsigned") console.warn(`socketcan: unknown signal type "${type}", treating as unsigned`);
 	return 0;
 }
 

--- a/src/socketcan.ts
+++ b/src/socketcan.ts
@@ -40,6 +40,15 @@ import * as _signals from "../build/Release/can_signals.node";
 
 import * as kcd from "./parse_kcd";
 
+// Maps KCD type string to the numeric SIGNAL_TYPE expected by the native addon.
+// 0=unsigned, 1=signed, 2=float32 (single), 3=float64 (double)
+function signalTypeCode(type: string): number {
+	if (type === "signed") return 1;
+	if (type === "single") return 2;
+	if (type === "double") return 3;
+	return 0;
+}
+
 /**
  * @method createRawChannel
  * @param channel {string} Channel name (e.g. vcan0)
@@ -387,7 +396,7 @@ export class DatabaseService {
 				s.bitOffset,
 				s.bitLength,
 				s.endianess == "little",
-				s.type == "signed"
+				signalTypeCode(s.type)
 			);
 
 			let val = ret[0] + (ret[1] << 32);
@@ -449,34 +458,48 @@ export class DatabaseService {
 
 			let val = s.value!;
 
-			// Apply factor/intercept and convert to Integer
+			// Apply scaling (slope/intercept).  For float/double signals these are
+			// typically 1/0 and the division/subtraction is a no-op, but we honour
+			// them if the KCD definition carries non-default values.
 			val -= s.intercept;
 			val /= s.slope;
-
-			// Make sure we are sending an integer because the division above could change it to a float.
-			val = Math.round(val);
 
 			if (m.len == 0) {
 				return;
 			}
 
-			const word1 = val & 0xffffffff;
-			let word2 = 0;
+			const typeCode = signalTypeCode(s.type);
 
-			// shift doesn't work above 32 bit, only do this if required to save cycles
-			if (val > 0xffffffff) {
-				word2 = val / Math.pow(2, 32);
+			if (s.type === "single" || s.type === "double") {
+				// Pass the floating-point value directly; the native addon handles
+				// the IEEE-754 bit reinterpretation and byte-order placement.
+				_signals.encodeSignal(
+					canmsg.data,
+					s.bitOffset,
+					s.bitLength,
+					s.endianess == "little",
+					typeCode,
+					val
+				);
+			} else {
+				// Integer path: round and split into two 32-bit words.
+				val = Math.round(val);
+				const word1 = val & 0xffffffff;
+				let word2 = 0;
+				// Bit-shift doesn't work above 32 bits; use division if needed.
+				if (val > 0xffffffff) {
+					word2 = val / Math.pow(2, 32);
+				}
+				_signals.encodeSignal(
+					canmsg.data,
+					s.bitOffset,
+					s.bitLength,
+					s.endianess == "little",
+					typeCode,
+					word1,
+					word2
+				);
 			}
-
-			_signals.encodeSignal(
-				canmsg.data,
-				s.bitOffset,
-				s.bitLength,
-				s.endianess == "little",
-				s.type == "signed",
-				word1,
-				word2
-			);
 		});
 
 		this.channel.send(canmsg);

--- a/test/test-signal_conversion.js
+++ b/test/test-signal_conversion.js
@@ -152,4 +152,128 @@ describe('signals', function() {
 
         done();
     });
+
+    // SIGNAL_TYPE constants: 0=unsigned, 1=signed, 2=float32, 3=float64
+    const FLOAT32 = 2;
+    const FLOAT64 = 3;
+
+    it('should encode float32 little endian', function(done) {
+        // 1.0f = 0x3F800000 → LE bytes [0x00, 0x00, 0x80, 0x3F]
+        data = Buffer.alloc(8);
+        signals.encodeSignal(data, 0, 32, true, FLOAT32, 1.0);
+        assert.deepEqual(data, Buffer.from([0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x00, 0x00]));
+
+        // -1.0f = 0xBF800000 → LE bytes [0x00, 0x00, 0x80, 0xBF]
+        data = Buffer.alloc(8);
+        signals.encodeSignal(data, 0, 32, true, FLOAT32, -1.0);
+        assert.deepEqual(data, Buffer.from([0x00, 0x00, 0x80, 0xBF, 0x00, 0x00, 0x00, 0x00]));
+
+        // float at bit offset 32 (bytes 4–7)
+        data = Buffer.alloc(8);
+        signals.encodeSignal(data, 32, 32, true, FLOAT32, 1.0);
+        assert.deepEqual(data, Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x3F]));
+
+        done();
+    });
+
+    it('should decode float32 little endian', function(done) {
+        // 1.0f LE bytes [0x00, 0x00, 0x80, 0x3F]
+        data = Buffer.from([0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x00, 0x00]);
+        assert.deepEqual(signals.decodeSignal(data, 0, 32, true, FLOAT32), [1.0, 0]);
+
+        // -1.0f LE bytes [0x00, 0x00, 0x80, 0xBF]
+        data = Buffer.from([0x00, 0x00, 0x80, 0xBF, 0x00, 0x00, 0x00, 0x00]);
+        assert.deepEqual(signals.decodeSignal(data, 0, 32, true, FLOAT32), [-1.0, 0]);
+
+        // float at bit offset 32
+        data = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x3F]);
+        assert.deepEqual(signals.decodeSignal(data, 32, 32, true, FLOAT32), [1.0, 0]);
+
+        done();
+    });
+
+    it('should encode float32 big endian', function(done) {
+        // 1.0f = 0x3F800000 → BE bytes [0x3F, 0x80, 0x00, 0x00]
+        data = Buffer.alloc(8);
+        signals.encodeSignal(data, 0, 32, false, FLOAT32, 1.0);
+        assert.deepEqual(data, Buffer.from([0x3F, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]));
+
+        // -1.0f = 0xBF800000 → BE bytes [0xBF, 0x80, 0x00, 0x00]
+        data = Buffer.alloc(8);
+        signals.encodeSignal(data, 0, 32, false, FLOAT32, -1.0);
+        assert.deepEqual(data, Buffer.from([0xBF, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]));
+
+        // float at bit offset 32 (bytes 4–7)
+        data = Buffer.alloc(8);
+        signals.encodeSignal(data, 32, 32, false, FLOAT32, 1.0);
+        assert.deepEqual(data, Buffer.from([0x00, 0x00, 0x00, 0x00, 0x3F, 0x80, 0x00, 0x00]));
+
+        done();
+    });
+
+    it('should decode float32 big endian', function(done) {
+        // 1.0f BE bytes [0x3F, 0x80, 0x00, 0x00]
+        data = Buffer.from([0x3F, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        assert.deepEqual(signals.decodeSignal(data, 0, 32, false, FLOAT32), [1.0, 0]);
+
+        // -1.0f BE bytes [0xBF, 0x80, 0x00, 0x00]
+        data = Buffer.from([0xBF, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        assert.deepEqual(signals.decodeSignal(data, 0, 32, false, FLOAT32), [-1.0, 0]);
+
+        // float at bit offset 32
+        data = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x3F, 0x80, 0x00, 0x00]);
+        assert.deepEqual(signals.decodeSignal(data, 32, 32, false, FLOAT32), [1.0, 0]);
+
+        done();
+    });
+
+    it('should round-trip float32 for values not exactly representable', function(done) {
+        const val = Math.fround(3.14); // exact float32 representation
+        data = Buffer.alloc(8);
+        signals.encodeSignal(data, 0, 32, true, FLOAT32, val);
+        const result = signals.decodeSignal(data, 0, 32, true, FLOAT32);
+        assert.strictEqual(result[0], val);
+        done();
+    });
+
+    it('should encode float64 little endian', function(done) {
+        // 1.0 double = 0x3FF0000000000000 → LE bytes [0x00,0x00,0x00,0x00,0x00,0x00,0xF0,0x3F]
+        data = Buffer.alloc(8);
+        signals.encodeSignal(data, 0, 64, true, FLOAT64, 1.0);
+        assert.deepEqual(data, Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F]));
+
+        done();
+    });
+
+    it('should decode float64 little endian', function(done) {
+        data = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F]);
+        assert.deepEqual(signals.decodeSignal(data, 0, 64, true, FLOAT64), [1.0, 0]);
+
+        done();
+    });
+
+    it('should encode float64 big endian', function(done) {
+        // 1.0 double BE bytes [0x3F,0xF0,0x00,0x00,0x00,0x00,0x00,0x00]
+        data = Buffer.alloc(8);
+        signals.encodeSignal(data, 0, 64, false, FLOAT64, 1.0);
+        assert.deepEqual(data, Buffer.from([0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]));
+
+        done();
+    });
+
+    it('should decode float64 big endian', function(done) {
+        data = Buffer.from([0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
+        assert.deepEqual(signals.decodeSignal(data, 0, 64, false, FLOAT64), [1.0, 0]);
+
+        done();
+    });
+
+    it('should round-trip float64', function(done) {
+        const val = 3.141592653589793;
+        data = Buffer.alloc(8);
+        signals.encodeSignal(data, 0, 64, true, FLOAT64, val);
+        const result = signals.decodeSignal(data, 0, 64, true, FLOAT64);
+        assert.strictEqual(result[0], val);
+        done();
+    });
 });

--- a/test/test-signal_conversion.js
+++ b/test/test-signal_conversion.js
@@ -3,6 +3,12 @@ var assert = require('assert');
 var signals = require('../build/Release/can_signals');
 var buffer = require('buffer');
 
+// SIGNAL_TYPE constants (mirror the native enum in signals.cc)
+var SIGNAL_UNSIGNED = 0;
+var SIGNAL_SIGNED   = 1;
+var SIGNAL_FLOAT32  = 2;
+var SIGNAL_FLOAT64  = 3;
+
 describe('signals', function() {
     it('should properly encode', function(done) {
         data = Buffer.from([0, 0, 0, 0, 0, 0, 0, 0]);
@@ -153,24 +159,20 @@ describe('signals', function() {
         done();
     });
 
-    // SIGNAL_TYPE constants: 0=unsigned, 1=signed, 2=float32, 3=float64
-    const FLOAT32 = 2;
-    const FLOAT64 = 3;
-
     it('should encode float32 little endian', function(done) {
         // 1.0f = 0x3F800000 → LE bytes [0x00, 0x00, 0x80, 0x3F]
         data = Buffer.alloc(8);
-        signals.encodeSignal(data, 0, 32, true, FLOAT32, 1.0);
+        signals.encodeSignal(data, 0, 32, true, SIGNAL_FLOAT32, 1.0);
         assert.deepEqual(data, Buffer.from([0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x00, 0x00]));
 
         // -1.0f = 0xBF800000 → LE bytes [0x00, 0x00, 0x80, 0xBF]
         data = Buffer.alloc(8);
-        signals.encodeSignal(data, 0, 32, true, FLOAT32, -1.0);
+        signals.encodeSignal(data, 0, 32, true, SIGNAL_FLOAT32, -1.0);
         assert.deepEqual(data, Buffer.from([0x00, 0x00, 0x80, 0xBF, 0x00, 0x00, 0x00, 0x00]));
 
         // float at bit offset 32 (bytes 4–7)
         data = Buffer.alloc(8);
-        signals.encodeSignal(data, 32, 32, true, FLOAT32, 1.0);
+        signals.encodeSignal(data, 32, 32, true, SIGNAL_FLOAT32, 1.0);
         assert.deepEqual(data, Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x3F]));
 
         done();
@@ -179,15 +181,15 @@ describe('signals', function() {
     it('should decode float32 little endian', function(done) {
         // 1.0f LE bytes [0x00, 0x00, 0x80, 0x3F]
         data = Buffer.from([0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x00, 0x00]);
-        assert.deepEqual(signals.decodeSignal(data, 0, 32, true, FLOAT32), [1.0, 0]);
+        assert.deepEqual(signals.decodeSignal(data, 0, 32, true, SIGNAL_FLOAT32), [1.0, 0]);
 
         // -1.0f LE bytes [0x00, 0x00, 0x80, 0xBF]
         data = Buffer.from([0x00, 0x00, 0x80, 0xBF, 0x00, 0x00, 0x00, 0x00]);
-        assert.deepEqual(signals.decodeSignal(data, 0, 32, true, FLOAT32), [-1.0, 0]);
+        assert.deepEqual(signals.decodeSignal(data, 0, 32, true, SIGNAL_FLOAT32), [-1.0, 0]);
 
         // float at bit offset 32
         data = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80, 0x3F]);
-        assert.deepEqual(signals.decodeSignal(data, 32, 32, true, FLOAT32), [1.0, 0]);
+        assert.deepEqual(signals.decodeSignal(data, 32, 32, true, SIGNAL_FLOAT32), [1.0, 0]);
 
         done();
     });
@@ -195,17 +197,17 @@ describe('signals', function() {
     it('should encode float32 big endian', function(done) {
         // 1.0f = 0x3F800000 → BE bytes [0x3F, 0x80, 0x00, 0x00]
         data = Buffer.alloc(8);
-        signals.encodeSignal(data, 0, 32, false, FLOAT32, 1.0);
+        signals.encodeSignal(data, 0, 32, false, SIGNAL_FLOAT32, 1.0);
         assert.deepEqual(data, Buffer.from([0x3F, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]));
 
         // -1.0f = 0xBF800000 → BE bytes [0xBF, 0x80, 0x00, 0x00]
         data = Buffer.alloc(8);
-        signals.encodeSignal(data, 0, 32, false, FLOAT32, -1.0);
+        signals.encodeSignal(data, 0, 32, false, SIGNAL_FLOAT32, -1.0);
         assert.deepEqual(data, Buffer.from([0xBF, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]));
 
         // float at bit offset 32 (bytes 4–7)
         data = Buffer.alloc(8);
-        signals.encodeSignal(data, 32, 32, false, FLOAT32, 1.0);
+        signals.encodeSignal(data, 32, 32, false, SIGNAL_FLOAT32, 1.0);
         assert.deepEqual(data, Buffer.from([0x00, 0x00, 0x00, 0x00, 0x3F, 0x80, 0x00, 0x00]));
 
         done();
@@ -214,15 +216,15 @@ describe('signals', function() {
     it('should decode float32 big endian', function(done) {
         // 1.0f BE bytes [0x3F, 0x80, 0x00, 0x00]
         data = Buffer.from([0x3F, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
-        assert.deepEqual(signals.decodeSignal(data, 0, 32, false, FLOAT32), [1.0, 0]);
+        assert.deepEqual(signals.decodeSignal(data, 0, 32, false, SIGNAL_FLOAT32), [1.0, 0]);
 
         // -1.0f BE bytes [0xBF, 0x80, 0x00, 0x00]
         data = Buffer.from([0xBF, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
-        assert.deepEqual(signals.decodeSignal(data, 0, 32, false, FLOAT32), [-1.0, 0]);
+        assert.deepEqual(signals.decodeSignal(data, 0, 32, false, SIGNAL_FLOAT32), [-1.0, 0]);
 
         // float at bit offset 32
         data = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x3F, 0x80, 0x00, 0x00]);
-        assert.deepEqual(signals.decodeSignal(data, 32, 32, false, FLOAT32), [1.0, 0]);
+        assert.deepEqual(signals.decodeSignal(data, 32, 32, false, SIGNAL_FLOAT32), [1.0, 0]);
 
         done();
     });
@@ -230,8 +232,8 @@ describe('signals', function() {
     it('should round-trip float32 for values not exactly representable', function(done) {
         const val = Math.fround(3.14); // exact float32 representation
         data = Buffer.alloc(8);
-        signals.encodeSignal(data, 0, 32, true, FLOAT32, val);
-        const result = signals.decodeSignal(data, 0, 32, true, FLOAT32);
+        signals.encodeSignal(data, 0, 32, true, SIGNAL_FLOAT32, val);
+        const result = signals.decodeSignal(data, 0, 32, true, SIGNAL_FLOAT32);
         assert.strictEqual(result[0], val);
         done();
     });
@@ -239,7 +241,7 @@ describe('signals', function() {
     it('should encode float64 little endian', function(done) {
         // 1.0 double = 0x3FF0000000000000 → LE bytes [0x00,0x00,0x00,0x00,0x00,0x00,0xF0,0x3F]
         data = Buffer.alloc(8);
-        signals.encodeSignal(data, 0, 64, true, FLOAT64, 1.0);
+        signals.encodeSignal(data, 0, 64, true, SIGNAL_FLOAT64, 1.0);
         assert.deepEqual(data, Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F]));
 
         done();
@@ -247,7 +249,7 @@ describe('signals', function() {
 
     it('should decode float64 little endian', function(done) {
         data = Buffer.from([0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xF0, 0x3F]);
-        assert.deepEqual(signals.decodeSignal(data, 0, 64, true, FLOAT64), [1.0, 0]);
+        assert.deepEqual(signals.decodeSignal(data, 0, 64, true, SIGNAL_FLOAT64), [1.0, 0]);
 
         done();
     });
@@ -255,7 +257,7 @@ describe('signals', function() {
     it('should encode float64 big endian', function(done) {
         // 1.0 double BE bytes [0x3F,0xF0,0x00,0x00,0x00,0x00,0x00,0x00]
         data = Buffer.alloc(8);
-        signals.encodeSignal(data, 0, 64, false, FLOAT64, 1.0);
+        signals.encodeSignal(data, 0, 64, false, SIGNAL_FLOAT64, 1.0);
         assert.deepEqual(data, Buffer.from([0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]));
 
         done();
@@ -263,7 +265,7 @@ describe('signals', function() {
 
     it('should decode float64 big endian', function(done) {
         data = Buffer.from([0x3F, 0xF0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]);
-        assert.deepEqual(signals.decodeSignal(data, 0, 64, false, FLOAT64), [1.0, 0]);
+        assert.deepEqual(signals.decodeSignal(data, 0, 64, false, SIGNAL_FLOAT64), [1.0, 0]);
 
         done();
     });
@@ -271,9 +273,57 @@ describe('signals', function() {
     it('should round-trip float64', function(done) {
         const val = 3.141592653589793;
         data = Buffer.alloc(8);
-        signals.encodeSignal(data, 0, 64, true, FLOAT64, val);
-        const result = signals.decodeSignal(data, 0, 64, true, FLOAT64);
+        signals.encodeSignal(data, 0, 64, true, SIGNAL_FLOAT64, val);
+        const result = signals.decodeSignal(data, 0, 64, true, SIGNAL_FLOAT64);
         assert.strictEqual(result[0], val);
+        done();
+    });
+
+    it('should round-trip float64 with negative value', function(done) {
+        const val = -2.718281828459045;
+        data = Buffer.alloc(8);
+        signals.encodeSignal(data, 0, 64, true, SIGNAL_FLOAT64, val);
+        assert.strictEqual(signals.decodeSignal(data, 0, 64, true, SIGNAL_FLOAT64)[0], val);
+        // big-endian too
+        data = Buffer.alloc(8);
+        signals.encodeSignal(data, 0, 64, false, SIGNAL_FLOAT64, val);
+        assert.strictEqual(signals.decodeSignal(data, 0, 64, false, SIGNAL_FLOAT64)[0], val);
+        done();
+    });
+
+    it('should handle IEEE-754 special values for float32', function(done) {
+        for (const val of [Infinity, -Infinity, NaN]) {
+            data = Buffer.alloc(8);
+            signals.encodeSignal(data, 0, 32, true, SIGNAL_FLOAT32, val);
+            const decoded = signals.decodeSignal(data, 0, 32, true, SIGNAL_FLOAT32)[0];
+            if (isNaN(val)) {
+                assert.ok(isNaN(decoded), 'NaN should round-trip as NaN');
+            } else {
+                assert.strictEqual(decoded, val);
+            }
+        }
+        done();
+    });
+
+    it('should handle IEEE-754 special values for float64', function(done) {
+        for (const val of [Infinity, -Infinity, NaN]) {
+            data = Buffer.alloc(8);
+            signals.encodeSignal(data, 0, 64, true, SIGNAL_FLOAT64, val);
+            const decoded = signals.decodeSignal(data, 0, 64, true, SIGNAL_FLOAT64)[0];
+            if (isNaN(val)) {
+                assert.ok(isNaN(decoded), 'NaN should round-trip as NaN');
+            } else {
+                assert.strictEqual(decoded, val);
+            }
+        }
+        done();
+    });
+
+    it('should decode correctly when wrong bitLength is passed for float32', function(done) {
+        // effectiveBitLength override: even if caller passes 16, we should read 32 bits
+        data = Buffer.from([0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x00, 0x00]);
+        const result = signals.decodeSignal(data, 0, 16 /* wrong */, true, SIGNAL_FLOAT32);
+        assert.strictEqual(result[0], 1.0);
         done();
     });
 });


### PR DESCRIPTION
## Summary

Closes #59 — adds IEEE-754 `single` (float32) and `double` (float64) signal type support throughout the encode/decode pipeline, plus a follow-up C++20 cleanup of the native addon.

**Feature (`native/signals.cc`, `src/`):**
- New `SIGNAL_TYPE` enum (0=unsigned, 1=signed, 2=float32, 3=float64). `DecodeSignal` and `EncodeSignal` accept the type as a number **or** a boolean (backward-compatible with all existing callers).
- For float/double, the raw bit pattern from `_getvalue`/`_setvalue` is reinterpreted via `std::bit_cast` — no extra byte-swapping needed because the existing `le64toh`/`be64toh` infrastructure already places the bytes in the correct order.
- `src/can_signals.d.ts` — updated declarations; `SignalType = boolean | 0 | 1 | 2 | 3`.
- `src/parse_kcd.ts` — `Signal.type` widened to `"signed" | "unsigned" | "single" | "double"`.
- `src/socketcan.ts` — `signalTypeCode()` maps KCD type strings to native enum values; float/double signals skip `Math.round()` and pass the value directly instead of a word1/word2 split.
- `test/test-signal_conversion.js` — 12 new test cases: both byte orders (Intel LE / Motorola BE) for float32 and float64, encode, decode, non-zero bit offset, round-trip, and IEEE-754 special values (Inf, -Inf, NaN).

**C++20 cleanup (`binding.gyp`, `native/signals.cc`):**
- Build: `-std=c++20` added to both addon targets.
- Removed vestigial `__STDC_LIMIT_MACROS`; switched to `<cstdint>` / `<cstring>` / `<bit>`.
- `typedef enum` → `enum class` for `ENDIANESS` and `SIGNAL_TYPE` (scoped, no implicit int conversion).
- Fixed strict-aliasing UB in `_getvalue` / `_setvalue`: pointer casts replaced with `memcpy`-based loads; `_setvalue` signature corrected from misleading `data[8]` to `uint8_t*`.
- `u_int*_t` (POSIX-only) → `uint*_t` (ISO C++) throughout.
- `[[nodiscard]]` on `_getvalue`.
- `_parse_signal_type` now throws `TypeError` on unknown values instead of silently returning unsigned.
- `memcpy` type-punning replaced with `std::bit_cast`.
- All C-style casts replaced with `static_cast<>`.
- Signed decode: `int32_t` → `int64_t`; XOR-subtract sign-extension handles signals wider than 32 bits without UB.

## Byte order correctness

`_getvalue` converts the 8-byte CAN frame to host byte order before bit extraction. After that, `std::bit_cast`-ing the extracted `uint32_t`/`uint64_t` directly into `float`/`double` yields the correct IEEE-754 value on any host endianness. Tests verify this for both Intel (LE) and Motorola (BE) at offsets 0 and 32.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Checklist

- [x] `npm run build:all` passes (or validated via `docker build -f Dockerfile.build-test .` on macOS)
- [x] `npm run lint` passes
- [x] Tests added or updated for changed behaviour
- [x] `npm test` passes (requires `sh prepare_test_env.sh` first)
- [ ] CHANGELOG.md updated if this is a user-facing change