### PR TITLE
fix: bound CAN data length before memcpy in Send/SendFD (#199, #200)

### DIFF
--- a/native/can.cc
+++ b/native/can.cc
@@ -307,6 +307,7 @@ private:
     CHECK_CONDITION(dataArg.IsBuffer(), "Data field must be a Buffer");
 
     Napi::Buffer<uint8_t> dataBuf = dataArg.As<Napi::Buffer<uint8_t>>();
+    CHECK_CONDITION(dataBuf.ByteLength() <= sizeof(frame.data), "Data field too long for a CAN frame (max 8 bytes)");
     frame.can_dlc = dataBuf.ByteLength();
     memcpy(frame.data, dataBuf.Data(), frame.can_dlc);
 
@@ -359,6 +360,7 @@ private:
     CHECK_CONDITION(dataArg.IsBuffer(), "Data field must be a Buffer");
 
     Napi::Buffer<uint8_t> dataBuf = dataArg.As<Napi::Buffer<uint8_t>>();
+    CHECK_CONDITION(dataBuf.ByteLength() <= sizeof(frameFD.data), "Data field too long for a CAN FD frame (max 64 bytes)");
     frameFD.len = dataBuf.ByteLength();
     memset(frameFD.data, 0, sizeof(frameFD.data));
     memcpy(frameFD.data, dataBuf.Data(), frameFD.len);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "socketcan",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "socketcan",
-      "version": "4.2.4",
+      "version": "4.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "os": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "sebastian@sebastianhaas.info"
   },
   "description": "A SocketCAN abstraction layer for NodeJS.",
-  "version": "4.2.4",
+  "version": "4.2.5",
   "license": "MIT",
   "keywords": [
     "can",

--- a/test/test-raw_basic.js
+++ b/test/test-raw_basic.js
@@ -49,6 +49,40 @@ describe('RawChannel', function() {
         setTimeout(function() { channel.stop(); }, 100);
     });
 
+    it('should reject over-length data buffer in send()', function(done) {
+        var channel = can.createRawChannel("vcan0");
+
+        // A classic CAN frame carries at most 8 data bytes. A longer buffer must be
+        // rejected before the native memcpy to avoid a stack out-of-bounds write.
+        assert.throws(function() {
+            channel.send({ id: 0x123, data: Buffer.alloc(64, 0x41) });
+        });
+
+        // Exactly 8 bytes is still allowed.
+        assert.doesNotThrow(function() {
+            channel.send({ id: 0x123, data: Buffer.alloc(8, 0x41) });
+        });
+
+        done();
+    });
+
+    it('should reject over-length data buffer in sendFD()', function(done) {
+        var channel = can.createRawChannel("vcan0");
+
+        // A CAN FD frame carries at most 64 data bytes. A longer buffer must be
+        // rejected before the native memcpy to avoid a stack out-of-bounds write.
+        assert.throws(function() {
+            channel.sendFD({ id: 0x123, data: Buffer.alloc(128, 0x41) });
+        });
+
+        // Exactly 64 bytes is still allowed.
+        assert.doesNotThrow(function() {
+            channel.sendFD({ id: 0x123, data: Buffer.alloc(64, 0x41) });
+        });
+
+        done();
+    });
+
     it('should receive 100 messages', function(done) {
         var c1 = can.createRawChannelWithOptions("vcan0", { timestamps: true });
         var c2 = can.createRawChannelWithOptions("vcan0", { non_block_send: true });


### PR DESCRIPTION
## Summary

Closes #199
Closes #200

Fixes the stack out-of-bounds writes (CWE-787) reported in #199 (`RawChannel::Send`) and #200 (`RawChannel::SendFD`).

Both methods `memcpy` a caller-controlled JS `data` Buffer into a fixed-size stack field — `frame.data[8]` and `frameFD.data[64]` respectively — using the Buffer's own byte length as the copy size, with **no upper bound before the copy**. A `data` Buffer longer than the field overflows it and smashes adjacent stack memory:

```js
ch.send({ id: 0x123, data: Buffer.alloc(64, 0x41) });   // 64 > 8  -> overflows frame.data[8]
ch.sendFD({ id: 0x123, data: Buffer.alloc(128, 0x41) }); // 128 > 64 -> overflows frameFD.data[64]
```

In `SendFD` the existing `if (frameFD.len > 64) frameFD.len = 64;` clamp runs **after** the `memcpy`, so it only bounds the frame's `len` field, never the copy.

## Fix

Add a length check **before** each `memcpy`, sized to the actual struct field via `sizeof(...)`, using the existing `CHECK_CONDITION` pattern:

- `Send`: reject `ByteLength() > sizeof(frame.data)` (8 bytes, classic CAN frame)
- `SendFD`: reject `ByteLength() > sizeof(frameFD.data)` (64 bytes, CAN FD frame)

Throwing rather than silently truncating surfaces the caller's mistake instead of quietly sending a malformed frame. The now-unreachable `len > 64` clamp in `SendFD` is left in place as defense-in-depth for the `len2dlc[]` lookup.

## Tests

Added regression tests in `test/test-raw_basic.js` asserting that over-length buffers throw while the exact maximum (8 / 64 bytes) is still accepted.

## Validation

- Native addon compiles cleanly via `docker build -f Dockerfile.build-test` .
- Test file syntax-checked with `node --check`.
- ⚠️ The mocha suite was **not** run end-to-end: it requires `vcan0`/`vcan1`, and the Docker Desktop VM kernel used for local validation has no `vcan` module. The runtime tests should be verified on CI / a Linux host with kernel CAN support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
