### PR TITLE
Add runtime CAN bitrate configuration

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Prepare Ubuntu
         run: |
           sudo apt-get install -y can-utils
+          sudo apt-get install -y libsocketcan-dev
           sudo apt-get install -y libnode-dev
           sudo apt-get install linux-modules-extra-$(uname -r)
 

--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Prepare Ubuntu
         run: |
           sudo apt-get install -y can-utils
+          sudo apt-get install -y libsocketcan-dev
           sudo apt-get install -y libnode-dev
           sudo apt-get install linux-modules-extra-$(uname -r)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+- `setCanBitrate(interfaceName, bitrate)` changes a physical CAN interface's
+  arbitration bitrate while preserving whether the interface was active or
+  stopped.
+
+### Changed
+- Building the native addon now requires the `libsocketcan` development
+  package.
+
 ## [4.1.0] - 2026-05-17
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Thanks for your interest in contributing to `socketcan`. This is a small Linux-o
 
 - Node.js ≥ 22
 - `node-gyp` build toolchain (`build-essential`, `python3`)
+- `libsocketcan` development headers and library (`libsocketcan-dev` on Debian/Ubuntu)
 - For tests: Linux kernel with SocketCAN modules (`vcan`)
 
 ## Getting started

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get update
 RUN apt-get -y install curl gnupg git python3-pip
 
 RUN apt-get install -y gcc g++ make
-RUN apt-get install -y can-utils
+RUN apt-get install -y can-utils iproute2 libsocketcan-dev
 #RUN apt-get install -y libnode-dev
 #RUN apt-get install linux-modules-extra-$(uname -r)
 
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_22.x | bash -
 RUN apt-get -y install nodejs

--- a/Dockerfile.build-test
+++ b/Dockerfile.build-test
@@ -5,6 +5,8 @@ RUN apt-get update && apt-get install -y \
     make \
     g++ \
     can-utils \
+    iproute2 \
+    libsocketcan-dev \
     --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ db_instr.send("TankController");
 channel.stop()
 ```
 
+Changing the bitrate of a physical CAN interface:
+
+```javascript
+var can = require("socketcan");
+
+can.setCanBitrate("can0", 500000);
+```
+
+`setCanBitrate` accepts integer arbitration bitrates from 1 kbit/s through
+1 Mbit/s. If the interface is active, it is stopped while the bitrate is
+changed and then restored to the active state; an already stopped interface
+remains stopped. The process needs permission to administer network
+interfaces (for example, `CAP_NET_ADMIN`).
+
 Usage (TypeScript)
 ------------------
 
@@ -114,6 +128,17 @@ Documentation
 
 Install
 -------
+
+The native addon links against
+[libsocketcan](https://git.pengutronix.de/cgit/tools/libsocketcan/). Install its
+development package before installing `socketcan`. On Debian and Ubuntu:
+
+```shell
+    $ sudo apt-get install libsocketcan-dev
+```
+
+Use the equivalent `libsocketcan` development package on other Linux
+distributions.
 
 There are two options for installing node-can:
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -10,3 +10,12 @@ sh prepare_test_env.sh   # one-time: creates vcan0 and vcan1
 npm test                 # run the full test suite
 npx mocha test/test-signal_conversion.js  # run a single file
 ```
+
+Bitrate validation and failure recovery are covered with `vcan`. A successful
+bitrate change must be verified with physical CAN hardware because virtual CAN
+interfaces do not implement bus timing:
+
+```sh
+sudo node -e 'require("./dist/socketcan").setCanBitrate("can0", 500000)'
+ip -details link show can0
+```

--- a/binding.gyp
+++ b/binding.gyp
@@ -7,6 +7,7 @@
         "<!@(node -p \"require('node-addon-api').include_dir\")"
       ],
       "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
+      "libraries": [ "-lsocketcan" ],
       "cflags_cc": [ "-std=c++20" ]
     },
     {

--- a/native/can.cc
+++ b/native/can.cc
@@ -40,9 +40,14 @@
 #include <net/if.h>
 
 #include <linux/can.h>
+#include <linux/can/netlink.h>
 #include <linux/can/raw.h>
 #include <linux/sockios.h>
+#include <libsocketcan.h>
 
+#include <cmath>
+#include <cstdint>
+#include <cerrno>
 #include <vector>
 #include <string>
 
@@ -56,6 +61,9 @@
 
 #define likely(x)   __builtin_expect( x , 1)
 #define unlikely(x) __builtin_expect( x , 0)
+
+#define MIN_CAN_BITRATE 1000
+#define MAX_CAN_BITRATE 1000000
 
 /**
  * Basic CAN & CAN_FD access
@@ -706,9 +714,127 @@ private:
 
 //-----------------------------------------------------------------------------------------
 
+static std::string LibsocketcanError(const std::string& operation,
+                                     const std::string& interface_name,
+                                     int error_number)
+{
+  std::string message = "setCanBitrate(" + interface_name + "): failed to " + operation;
+  if (error_number != 0)
+    message += ": " + std::string(strerror(error_number));
+  return message;
+}
+
+/**
+ * Change the arbitration bitrate of a CAN interface, preserving whether the
+ * interface was active or stopped before the call.
+ *
+ * @method setCanBitrate
+ * @param interface {string} CAN interface name (e.g. can0)
+ * @param bitrate {integer} bitrate in bits per second (1 kbit/s to 1 Mbit/s)
+ */
+static Napi::Value SetCanBitrate(const Napi::CallbackInfo& info)
+{
+  Napi::Env env = info.Env();
+
+  if (info.Length() < 2) {
+    Napi::TypeError::New(env, "setCanBitrate requires an interface name and bitrate")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  if (!info[0].IsString()) {
+    Napi::TypeError::New(env, "Interface name must be a string").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  std::string interface_name = info[0].As<Napi::String>().Utf8Value();
+  if (interface_name.empty()) {
+    Napi::TypeError::New(env, "Interface name must not be empty").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  if (!info[1].IsNumber()) {
+    Napi::TypeError::New(env, "Bitrate must be an integer").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  double bitrate_value = info[1].As<Napi::Number>().DoubleValue();
+  if (!std::isfinite(bitrate_value) || std::floor(bitrate_value) != bitrate_value) {
+    Napi::TypeError::New(env, "Bitrate must be an integer").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  if (bitrate_value < MIN_CAN_BITRATE || bitrate_value > MAX_CAN_BITRATE) {
+    Napi::RangeError::New(env, "Bitrate must be between 1000 and 1000000 bits per second")
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  const uint32_t bitrate = static_cast<uint32_t>(bitrate_value);
+  int initial_state;
+
+  errno = 0;
+  if (can_get_state(interface_name.c_str(), &initial_state) != 0) {
+    int error_number = errno;
+    Napi::Error::New(env, LibsocketcanError("query interface state", interface_name, error_number))
+        .ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  const bool restore_active_state = initial_state != CAN_STATE_STOPPED;
+
+  if (restore_active_state) {
+    errno = 0;
+    if (can_do_stop(interface_name.c_str()) != 0) {
+      int error_number = errno;
+      Napi::Error::New(env, LibsocketcanError("stop interface", interface_name, error_number))
+          .ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+  }
+
+  errno = 0;
+  if (can_set_bitrate(interface_name.c_str(), bitrate) != 0) {
+    int bitrate_error = errno;
+    std::string message =
+        LibsocketcanError("set bitrate to " + std::to_string(bitrate), interface_name, bitrate_error);
+
+    if (restore_active_state) {
+      errno = 0;
+      if (can_do_start(interface_name.c_str()) != 0) {
+        int restore_error = errno;
+        message += "; also failed to restore the active interface state";
+        if (restore_error != 0)
+          message += ": " + std::string(strerror(restore_error));
+      }
+    }
+
+    Napi::Error::New(env, message).ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+
+  if (restore_active_state) {
+    errno = 0;
+    if (can_do_start(interface_name.c_str()) != 0) {
+      int error_number = errno;
+      std::string message = "setCanBitrate(" + interface_name + "): bitrate changed to " +
+                            std::to_string(bitrate) +
+                            " but failed to restore the active interface state";
+      if (error_number != 0)
+        message += ": " + std::string(strerror(error_number));
+      Napi::Error::New(env, message).ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+  }
+
+  return env.Undefined();
+}
+
 static Napi::Object ModuleInit(Napi::Env env, Napi::Object exports)
 {
-  return RawChannel::Init(env, exports);
+  RawChannel::Init(env, exports);
+  exports.Set("setCanBitrate", Napi::Function::New(env, SetCanBitrate));
+  return exports;
 }
 
 NODE_API_MODULE(can, ModuleInit)

--- a/src/can.d.ts
+++ b/src/can.d.ts
@@ -1,4 +1,6 @@
 declare module "*can.node" {
+	export function setCanBitrate(interfaceName: string, bitrate: number): void;
+
 	export interface Message {
 		id: number;
 		ext: boolean;

--- a/src/socketcan.ts
+++ b/src/socketcan.ts
@@ -41,6 +41,22 @@ import * as _signals from "../build/Release/can_signals.node";
 import * as kcd from "./parse_kcd";
 
 /**
+ * Change the arbitration bitrate of a CAN interface.
+ *
+ * If the interface is active, it is stopped while the bitrate is changed and
+ * then restored to the active state. An interface that is already stopped
+ * remains stopped.
+ *
+ * @method setCanBitrate
+ * @param interfaceName CAN interface name (e.g. can0)
+ * @param bitrate bitrate in bits per second (1 kbit/s to 1 Mbit/s)
+ * @for exports
+ */
+export function setCanBitrate(interfaceName: string, bitrate: number): void {
+	can.setCanBitrate(interfaceName, bitrate);
+}
+
+/**
  * Numeric signal-type codes understood by the can_signals native addon.
  * Mirrors the SIGNAL_TYPE enum in native/signals.cc.
  */

--- a/test/test-raw_basic.js
+++ b/test/test-raw_basic.js
@@ -1,7 +1,44 @@
 var assert = require('assert')
+var fs = require('fs');
 
 var can = require('../dist/socketcan');
 var buffer = require('buffer');
+
+function interfaceIsUp(name) {
+    var flags = fs.readFileSync('/sys/class/net/' + name + '/flags', 'utf8');
+    return (parseInt(flags, 16) & 1) !== 0;
+}
+
+describe('setCanBitrate', function() {
+    it('should validate its arguments', function() {
+        assert.throws(function() { can.setCanBitrate(); }, TypeError);
+        assert.throws(function() { can.setCanBitrate(123, 125000); }, TypeError);
+        assert.throws(function() { can.setCanBitrate('', 125000); }, TypeError);
+        assert.throws(function() { can.setCanBitrate('can0', '125000'); }, TypeError);
+        assert.throws(function() { can.setCanBitrate('can0', 125000.5); }, TypeError);
+        assert.throws(function() { can.setCanBitrate('can0', NaN); }, TypeError);
+        assert.throws(function() { can.setCanBitrate('can0', Infinity); }, TypeError);
+        assert.throws(function() { can.setCanBitrate('can0', 999); }, RangeError);
+        assert.throws(function() { can.setCanBitrate('can0', 1000001); }, RangeError);
+    });
+
+    it('should report an error for a nonexistent interface', function() {
+        assert.throws(function() {
+            can.setCanBitrate('non_existent_can_interface', 125000);
+        }, /setCanBitrate\(non_existent_can_interface\): failed to query interface state/);
+    });
+
+    it('should not leave interfaces in a different administrative state on failure', function() {
+        assert.equal(interfaceIsUp('vcan0'), true);
+        assert.equal(interfaceIsUp('vcan1'), false);
+
+        assert.throws(function() { can.setCanBitrate('vcan0', 125000); });
+        assert.throws(function() { can.setCanBitrate('vcan1', 125000); });
+
+        assert.equal(interfaceIsUp('vcan0'), true);
+        assert.equal(interfaceIsUp('vcan1'), false);
+    });
+});
 
 describe('RawChannel', function() {
     it('should throw exception', function(done) {


### PR DESCRIPTION
## Summary

- add a synchronous `setCanBitrate(interfaceName, bitrate)` API backed by libsocketcan
- preserve the interface's prior active/stopped state across successful changes and failure recovery
- validate interface names and classic CAN arbitration bitrates from 1 kbit/s through 1 Mbit/s
- add the required libsocketcan build dependency to CI and Docker environments
- document installation, permissions, usage, and physical-hardware verification

## Why

Issue #75 requests an in-process way to switch a SocketCAN interface's bitrate instead of shelling out to `ip`. Physical CAN interfaces must be stopped before changing their bit timing, so the API manages that transition and restores the original administrative state.

## User impact

Consumers can call:

```js
can.setCanBitrate("can0", 500000);
```

The caller needs network-administration privileges. Building the addon now requires the system `libsocketcan` development package (`libsocketcan-dev` on Debian/Ubuntu).

## Validation

- `npm run build:ts`
- `npm run lint`
- Linux ARM64 Docker native build and libsocketcan link verification
- API export smoke test
- argument-validation and nonexistent-interface tests
- existing hardware-independent parsing/signal tests
- `npm pack --dry-run`

The state-preservation regression test is included for Linux CI. Docker Desktop's kernel does not expose the `vcan` device type, so a successful bitrate transition still requires physical CAN hardware for final verification.

Closes #75
