### PR TITLE
ci: use npm trusted publishing

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -6,21 +6,23 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: production
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22.22.2
+          node-version: 24.15.0
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
 
       - name: Prepare Ubuntu
         run: |
@@ -46,5 +48,3 @@ jobs:
 
       - name: Publish
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- grant the release workflow GitHub OIDC token permissions
- remove the long-lived `NPM_TOKEN` from `npm publish`
- use Node 24.15.0, which includes an OIDC-capable npm 11 release
- disable dependency caching for release builds
- update publish setup actions to their Node 24-based v6 releases

The npm trusted publisher must match workflow `npmpublish.yml` and GitHub environment `production`. Trusted publishing will automatically attach provenance to future public releases.

## Validation

- parsed `.github/workflows/npmpublish.yml` as YAML
- verified `actions/setup-node@v6` supports `package-manager-cache`
- verified `pnpm/action-setup@v6` runs on Node 24
- `git diff --check`

The OIDC exchange can only be exercised by the next real `npm publish` from a published GitHub release.