### PR TITLE
fix: recover RawChannel from transient POLLERR events

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -49,6 +49,8 @@ jobs:
           pnpm run lint
 
       - name: Perform tests
+        env:
+          NODE_CAN_RUN_PRIVILEGED_TESTS: '1'
         run: |
           sh prepare_test_env.sh
           pnpm run test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- `RawChannel` no longer stops permanently when a raw CAN socket reports the
+  recoverable `ENETDOWN` or `ENOBUFS` conditions through `POLLERR`. Pending
+  socket errors are inspected and cleared with `SO_ERROR`, allowing reception
+  to resume without consuming a queued CAN frame. Permanent interface removal
+  (`ENODEV`), hangups, invalid descriptors, and other polling failures still
+  stop the channel.
+
 ## [4.1.0] - 2026-05-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## [4.3.1] - 2026-09-05
+
 ### Fixed
 - `RawChannel` no longer stops permanently when a raw CAN socket reports the
   recoverable `ENETDOWN` or `ENOBUFS` conditions through `POLLERR`. Pending

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,14 @@ sh prepare_test_env.sh   # creates vcan0 and vcan1 (requires root / modprobe)
 pnpm test
 ```
 
+The raw-channel interface lifecycle tests create and remove their own
+`vcan-pollerr` interface. They are skipped by default; enable them when running
+as root or with passwordless `sudo` available:
+
+```sh
+NODE_CAN_RUN_PRIVILEGED_TESTS=1 pnpm test
+```
+
 Run a single test file:
 
 ```sh

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,5 +8,6 @@ Quick reference:
 ```sh
 sh prepare_test_env.sh   # one-time: creates vcan0 and vcan1
 pnpm test                 # run the full test suite
+NODE_CAN_RUN_PRIVILEGED_TESTS=1 pnpm test  # include link lifecycle tests (root or passwordless sudo required)
 pnpm exec mocha test/test-signal_conversion.js  # run a single file
 ```

--- a/native/can.cc
+++ b/native/can.cc
@@ -25,6 +25,7 @@
 #include <napi.h>
 #include <uv.h>
 
+#include <cerrno>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
@@ -513,6 +514,24 @@ private:
 
   static void * c_thread_entry(void *_this) { assert(_this); reinterpret_cast<RawChannel *>(_this)->ThreadEntry(); return NULL; }
 
+  bool ClearRecoverableSocketError()
+  {
+    int socketError = 0;
+    socklen_t socketErrorLength = sizeof(socketError);
+
+    // SO_ERROR returns and clears the pending socket error without consuming
+    // a queued CAN frame. A recv() here could silently discard valid data.
+    if (getsockopt(m_SocketFd, SOL_SOCKET, SO_ERROR, &socketError, &socketErrorLength) < 0)
+      return false;
+
+    // NETDEV_DOWN leaves a CAN_RAW socket bound, so it can receive again when
+    // the interface comes back up. ENOBUFS is also recoverable if a kernel or
+    // protocol implementation reports it asynchronously. NETDEV_UNREGISTER
+    // reports ENODEV and permanently unbinds the socket, so all other errors
+    // retain the existing fatal behaviour.
+    return socketError == ENETDOWN || socketError == ENOBUFS;
+  }
+
   void ThreadEntry()
   {
     struct pollfd pfd;
@@ -531,8 +550,22 @@ private:
 
       pthread_mutex_unlock(&m_ReadPendingMtx);
 
-      if (likely(poll(&pfd, 1, 100) >= 0))
+      int pollResult = poll(&pfd, 1, 100);
+
+      if (pollResult > 0)
       {
+        if (pfd.revents & (POLLHUP|POLLNVAL))
+        {
+          uv_async_send(&m_AsyncChannelStopped);
+          break;
+        }
+
+        if ((pfd.revents & POLLERR) && !ClearRecoverableSocketError())
+        {
+          uv_async_send(&m_AsyncChannelStopped);
+          break;
+        }
+
         if (likely(pfd.revents & POLLIN))
         {
           pthread_mutex_lock(&m_ReadPendingMtx);
@@ -540,15 +573,13 @@ private:
           m_ReadPending = true;
           pthread_mutex_unlock(&m_ReadPendingMtx);
         }
-
-        if (pfd.revents & (POLLHUP|POLLERR))
-        {
-          uv_async_send(&m_AsyncChannelStopped);
-          break;
-        }
       }
-      else
+      else if (pollResult < 0)
       {
+        if (errno == EINTR)
+          continue;
+
+        uv_async_send(&m_AsyncChannelStopped);
         break;
       }
     }

--- a/native/can.cc
+++ b/native/can.cc
@@ -514,7 +514,7 @@ private:
 
   static void * c_thread_entry(void *_this) { assert(_this); reinterpret_cast<RawChannel *>(_this)->ThreadEntry(); return NULL; }
 
-  bool ClearRecoverableSocketError()
+  [[nodiscard]] bool ClearRecoverableSocketError()
   {
     int socketError = 0;
     socklen_t socketErrorLength = sizeof(socketError);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "sebastian@sebastianhaas.info"
   },
   "description": "A SocketCAN abstraction layer for NodeJS.",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "license": "MIT",
   "keywords": [
     "can",

--- a/test/test-raw_basic.js
+++ b/test/test-raw_basic.js
@@ -26,14 +26,22 @@ describe('RawChannel', function() {
         done();
     });
 
-    it('should call onStopped if channel is destroyed', function(done) {
+    it('should stay active while the interface is down', function(done) {
         var channel = can.createRawChannel("vcan1");
+        var stopRequested = false;
+        var timeout;
 
         channel.addListener("onStopped", function() {
-            done();
+            clearTimeout(timeout);
+            done(stopRequested ? undefined : new Error('channel stopped while its interface was down'));
         });
 
         channel.start();
+
+        timeout = setTimeout(function() {
+            stopRequested = true;
+            channel.stop();
+        }, 100);
     });
 
     it('should call onStopped on stop()', function(done) {

--- a/test/test-raw_pollerr.js
+++ b/test/test-raw_pollerr.js
@@ -1,0 +1,169 @@
+var assert = require('assert');
+var childProcess = require('child_process');
+
+var can = require('../dist/socketcan');
+
+var interfaceName = 'vcan-pollerr';
+var runPrivilegedTests = process.env.NODE_CAN_RUN_PRIVILEGED_TESTS === '1';
+var describePrivileged = runPrivilegedTests ? describe : describe.skip;
+
+function runIp(args, ignoreFailure) {
+    var isRoot = typeof process.getuid === 'function' && process.getuid() === 0;
+    var command = isRoot ? 'ip' : 'sudo';
+    var commandArgs = isRoot ? args : [ '-n', 'ip' ].concat(args);
+
+    try {
+        childProcess.execFileSync(command, commandArgs, { stdio: 'pipe' });
+    } catch (error) {
+        if (!ignoreFailure) {
+            throw error;
+        }
+    }
+}
+
+function createInterface() {
+    runIp([ 'link', 'delete', 'dev', interfaceName ], true);
+    runIp([ 'link', 'add', 'dev', interfaceName, 'type', 'vcan' ]);
+    runIp([ 'link', 'set', 'dev', interfaceName, 'up' ]);
+}
+
+function deleteInterface() {
+    runIp([ 'link', 'delete', 'dev', interfaceName ], true);
+}
+
+describePrivileged('RawChannel interface lifecycle', function() {
+    this.timeout(5000);
+
+    beforeEach(function() {
+        createInterface();
+    });
+
+    afterEach(function() {
+        deleteInterface();
+    });
+
+    it('should resume receiving after the interface goes down and comes back up', function(done) {
+        var receiver = can.createRawChannel(interfaceName);
+        var sender = can.createRawChannelWithOptions(interfaceName, { non_block_send: true });
+        var expectedData = Buffer.from([ 0xca, 0xfe ]);
+        var expectedId = 0x215;
+        var finished = false;
+        var timers = [];
+
+        function later(callback, delay) {
+            timers.push(setTimeout(function() {
+                if (finished) {
+                    return;
+                }
+
+                try {
+                    callback();
+                } catch (error) {
+                    finish(error);
+                }
+            }, delay));
+        }
+
+        function finish(error) {
+            if (finished) {
+                return;
+            }
+
+            finished = true;
+            timers.forEach(clearTimeout);
+
+            try {
+                runIp([ 'link', 'set', 'dev', interfaceName, 'up' ]);
+            } catch (linkError) {
+                error = error || linkError;
+            }
+
+            try { receiver.stop(); } catch (_) {}
+            try { sender.stop(); } catch (_) {}
+            done(error);
+        }
+
+        receiver.addListener('onStopped', function() {
+            if (!finished) {
+                finish(new Error('receiver stopped after a recoverable interface-down event'));
+            }
+        });
+
+        sender.addListener('onStopped', function() {
+            if (!finished) {
+                finish(new Error('sender stopped after a recoverable interface-down event'));
+            }
+        });
+
+        receiver.addListener('onMessage', function(message) {
+            if (message.id !== expectedId) {
+                return;
+            }
+
+            try {
+                assert.deepEqual(message.data, expectedData);
+                finish();
+            } catch (error) {
+                finish(error);
+            }
+        });
+
+        receiver.start();
+        sender.start();
+
+        later(function() {
+            runIp([ 'link', 'set', 'dev', interfaceName, 'down' ]);
+
+            later(function() {
+                runIp([ 'link', 'set', 'dev', interfaceName, 'up' ]);
+
+                later(function() {
+                    sender.send({ id: expectedId, data: expectedData });
+                }, 200);
+            }, 300);
+        }, 100);
+
+        later(function() {
+            finish(new Error('timed out waiting for a frame after interface recovery'));
+        }, 4000);
+    });
+
+    it('should stop after the interface is permanently removed', function(done) {
+        var channel = can.createRawChannel(interfaceName);
+        var finished = false;
+        var timeout;
+
+        channel.addListener('onStopped', function() {
+            if (finished) {
+                return;
+            }
+
+            finished = true;
+            clearTimeout(timeout);
+            done();
+        });
+
+        channel.start();
+
+        setTimeout(function() {
+            try {
+                runIp([ 'link', 'delete', 'dev', interfaceName ]);
+            } catch (error) {
+                finished = true;
+                clearTimeout(timeout);
+                try { channel.stop(); } catch (_) {}
+                done(error);
+            }
+        }, 100);
+
+        timeout = setTimeout(function() {
+            if (finished) {
+                return;
+            }
+
+            finished = true;
+            try { channel.stop(); } catch (_) {}
+            done(new Error('channel did not stop after permanent interface removal'));
+        }, 3000);
+    });
+});


### PR DESCRIPTION
## Summary

- inspect and clear pending CAN socket errors with `SO_ERROR` when `poll` reports `POLLERR`
- keep `RawChannel` alive for recoverable `ENETDOWN` and `ENOBUFS` conditions
- retain fatal handling for `ENODEV`, `POLLHUP`, `POLLNVAL`, and unexpected socket errors
- retry `poll` after `EINTR` and notify on other poll failures instead of exiting the reader silently
- add opt-in privileged regression tests for interface recovery and permanent removal, enabled in CI
- bump the package version to `4.3.1` and publish the fix under the dated `4.3.1` changelog entry

## Analysis

The symptom reported in #215 is valid, but Linux 6.8 does not set `sk_err` when the socket receive queue fills; it increments `sk_drops` and drops the frame. CAN_RAW does set `ENETDOWN` for `NETDEV_DOWN` and `ENODEV` for `NETDEV_UNREGISTER`. A transient interface down/up event therefore matches the recoverable case, while unregistering the interface still requires recreating the channel.

Using `SO_ERROR` is important because it retrieves and clears the pending error without consuming a valid CAN frame in the reader thread.

PR #170 independently addresses the existing duplicate-stop lifecycle race and can be reviewed separately.

## Validation

Validated on Apple Container 1.2.2 (Linux/arm64) with a Linux 6.18.5 kernel built from Apple Containerization 0.40.1 and these options built in: `CONFIG_CAN`, `CONFIG_CAN_RAW`, `CONFIG_CAN_DEV`, and `CONFIG_CAN_VCAN`.

- [x] Native addon and TypeScript build on Linux/arm64 with Node 22
- [x] Lint passes
- [x] Automated vcan down/up test: neither channel stops and a frame is received after recovery
- [x] Automated vcan deletion test: permanent removal emits `onStopped`
- [x] Usable suite: 39 passing, including both privileged lifecycle tests
- [ ] Full suite: the existing `should call onStopped if channel is destroyed` test times out waiting for nondeterministic garbage collection; this is unrelated to the polling change

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Documentation
- [x] CI / tooling

## Checklist

- [x] Build passes
- [x] Lint passes
- [x] CHANGELOG.md updated
- [x] Automated privileged regression tests added
- [ ] Full test suite passes locally (one pre-existing GC-timing test fails)

Fixes #215
